### PR TITLE
Enhance resource management

### DIFF
--- a/test/unit/test_http_utils.py
+++ b/test/unit/test_http_utils.py
@@ -39,9 +39,13 @@ class TestSomewhatBufferedFileObject(unittest.TestCase):
         finally:
             sock.close()
 
-    def test_fail_flush(self):
+    def test_flush(self):
         with self._make_socket() as sock:
-            self.assertRaises(NotImplementedError, sock.flush)
+            try:
+                ret = sock.flush()
+            except NotImplementedError:
+                self.fail("Socket flush should not raised a NotImplementedError")
+            self.assertIsNone(ret)
 
     def test_fail_write(self):
         with self._make_socket() as sock:


### PR DESCRIPTION
These commits are first stabs at enhancing resource (FD/connection) management.

Unlike previously, HTTP connections aren't re-used as instance attributes, but closed when appropriate. This has as a drawback that e.g. for a multi-range request, multiple HTTP connections will be made.

The idea is to work around this inefficiency by leveraging a library-layer connection pool, e.g. using `urllib3` or something similar.
