### PR TITLE
Fix Swift 1.13 compatibility

### DIFF
--- a/swift_scality_backend/diskfile.py
+++ b/swift_scality_backend/diskfile.py
@@ -88,13 +88,17 @@ class SproxydFileSystem(object):
 
         conf_wants_splice = swift.common.utils.config_true_value(
             conf.get('splice', 'no'))
-        if conf_wants_splice and not swift.common.utils.system_has_splice():
+        try:
+            system_has_splice = swift.common.utils.system_has_splice()
+        except AttributeError:  # Old Swift versions
+            system_has_splice = False
+        if conf_wants_splice and not system_has_splice:
             self.logger.warn(
                 "Use of splice() requested (config says \"splice = %s\"), "
                 "but the system does not support it. "
                 "splice() will not be used." % conf.get('splice'))
 
-        if conf_wants_splice and swift.common.utils.system_has_splice():
+        if conf_wants_splice and system_has_splice:
             self.use_splice = True
 
     def __repr__(self):


### PR DESCRIPTION
When running Swift 1.13 and enabling `splice` in the configuration,
`system_has_splice` would be called`even though it doesn't exist in
that version of Swift (1.13 has no`splice` support).

This patch works around this.
