### PR TITLE
Use the `trace` decorator everywhere

### DIFF
--- a/swift_scality_backend/utils.py
+++ b/swift_scality_backend/utils.py
@@ -26,41 +26,12 @@ from swift_scality_backend.exceptions import SproxydConfException, \
 
 DEFAULT_LOGGER = logging.getLogger(__name__)
 
-# Monkey-patch Python logging to support `trace` logging
-TRACE_LEVEL = 5
-
-
-def monkey_patch_log_trace(level):
-    '''Monkey-patch `trace` support onto `logging.Logger`'''
-
-    assert not hasattr(logging.Logger, 'trace')
-
-    logging.addLevelName(level, 'TRACE')
-
-    def trace(self, msg, *args, **kwargs):
-        '''Logo 'msg % args' with severity 'TRACE'.
-
-        To pass exception information, use the keyword argument exc_info with a
-        true value, e.g.
-
-        logger.trace("Houston, we have a %s", "thorny problem", exc_info=1)
-        '''
-
-        if self.isEnabledFor(level):
-            self._log(level, msg, args, **kwargs)
-
-    logging.Logger.trace = trace
-
-monkey_patch_log_trace(TRACE_LEVEL)
-del monkey_patch_log_trace
-# End of monkey-patch
-
 
 def trace(f):
     '''Trace calls to a decorated function
 
     Using this decorator on a function will cause its execution to be logged at
-    `TRACE` level, including messages when the function is called (with a call
+    `DEBUG` level, including messages when the function is called (with a call
     identifier and the arguments), as well as when the function returns (also
     including the call identifier, and a representation of the return value or
     exception if applicable).
@@ -84,26 +55,26 @@ def trace(f):
 
         logger = getattr(maybe_self, 'logger', DEFAULT_LOGGER)
 
-        # Fast-path, don't do any of the 'expensive' things below if the trace
+        # Fast-path, don't do any of the 'expensive' things below if the debug
         # log level isn't enabled anyway
-        if not logger.isEnabledFor(TRACE_LEVEL):
+        if not logger.isEnabledFor(logging.DEBUG):
             return f(*args, **kwargs)
 
         # Get & bump call identifier, assume non-preemptive threading
         ctid, tid[0] = tid[0], tid[0] + 1
 
         all_args = inspect.getcallargs(f, *args, **kwargs)
-        logger.trace('==> %s (%d): call %r', name, ctid, all_args)
+        logger.debug('==> %s (%d): call %r', name, ctid, all_args)
 
         result = None
 
         try:
             result = f(*args, **kwargs)
         except BaseException as exc:
-            logger.trace('<== %s (%d): exception %r', name, ctid, exc)
+            logger.debug('<== %s (%d): exception %r', name, ctid, exc)
             raise
         else:
-            logger.trace('<== %s (%d): return %r', name, ctid, result)
+            logger.debug('<== %s (%d): return %r', name, ctid, result)
             return result
 
     return wrapped


### PR DESCRIPTION
Change the `trace` decorator to log at DEBUG level instead of
monkey patching the logger to introduce a new LOG_LEVEL.

Also, remove redundant logging.
