### PR TITLE
Use HTTP connections pool

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 https://launchpad.net/swift/juno/2.2.0/+download/swift-2.2.0.tar.gz
 eventlet>=0.9.15
+urllib3>=1.9,<2.0

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,8 @@
 
 import setuptools
 
+import swift_scality_backend
+
 setuptools.setup(
     name='swift-scality-backend',
     version='0.3.0',
@@ -29,7 +31,7 @@ setuptools.setup(
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python :: 2.7'],
-    install_requires=['swift>=1.13.1', 'eventlet>=0.9.15'],
+    install_requires=swift_scality_backend.__requires__,
     entry_points={
         'paste.app_factory': [
             'sproxyd_object=swift_scality_backend.server:app_factory'],

--- a/swift_scality_backend/__init__.py
+++ b/swift_scality_backend/__init__.py
@@ -1,0 +1,1 @@
+__requires__ = ['swift>=1.13.1', 'eventlet>=0.9.15', 'urllib3>=1.9']

--- a/swift_scality_backend/diskfile.py
+++ b/swift_scality_backend/diskfile.py
@@ -31,8 +31,6 @@ import swift.common.bufferedhttp
 import swift.common.exceptions
 import swift.common.swob
 import swift.common.utils
-import urllib3
-import urllib3.exceptions
 
 try:
     import swift.common.splice
@@ -45,6 +43,8 @@ from swift_scality_backend.exceptions import SproxydHTTPException, \
 import swift_scality_backend.http_utils
 import swift_scality_backend.splice_utils
 from swift_scality_backend import utils
+
+urllib3 = utils.get_urllib3()
 
 
 class SproxydFileSystem(object):

--- a/swift_scality_backend/diskfile.py
+++ b/swift_scality_backend/diskfile.py
@@ -30,6 +30,8 @@ import swift.common.bufferedhttp
 import swift.common.exceptions
 import swift.common.swob
 import swift.common.utils
+import urllib3
+import urllib3.exceptions
 
 try:
     import swift.common.splice
@@ -57,8 +59,8 @@ class SproxydFileSystem(object):
 
         self.healthcheck_threads = []
         self.sproxyd_hosts_set = set()
-        hosts = conf.get('sproxyd_host', 'localhost:81')
-        for host in hosts.strip(',').split(","):
+        hosts = conf.get('sproxyd_host', 'localhost:81').strip(',')
+        for host in hosts.split(","):
             ip_addr, port = host.strip().split(':')
             self.sproxyd_hosts_set.add((ip_addr, int(port)))
 
@@ -93,17 +95,25 @@ class SproxydFileSystem(object):
         if conf_wants_splice and system_has_splice:
             self.use_splice = True
 
+        timeout = urllib3.Timeout(connect=self.conn_timeout,
+                                  read=self.proxy_timeout)
+        # One HTTP Connection pool per sproxyd host
+        self.http_pools = urllib3.PoolManager(len(self.sproxyd_hosts_set),
+                                              timeout=timeout, retries=False,
+                                              maxsize=32)
+
     def ping(self, url):
+        """Retrieves the Sproxyd active configuration for health checking."""
         try:
-            with eventlet.Timeout(1):
-                conf = urllib.urlopen(url)
-                return utils.is_sproxyd_conf_valid(conf.read())
-        except (IOError, httplib.HTTPException, eventlet.Timeout) as e:
+            timeout = urllib3.Timeout(1)
+            conf = self.http_pools.request('GET', url, timeout=timeout)
+            return utils.is_sproxyd_conf_valid(conf.data)
+        except (IOError, urllib3.exceptions.HTTPError) as exc:
             self.logger.info("Could not read Sproxyd configuration at %s "
-                             "due to a network error: %r", url, e)
-        except SproxydConfException as e:
+                             "due to a network error: %r", url, exc)
+        except SproxydConfException as exc:
             self.logger.warning("Sproxyd configuration at %s is invalid: "
-                                "%s", url, e)
+                                "%s", url, exc)
         except:
             self.logger.exception("Unexpected exception during Sproxyd "
                                   "health check of %s", url)
@@ -162,28 +172,30 @@ class SproxydFileSystem(object):
         address, port = self.sproxyd_hosts.next()
         safe_path = self.base_path + urllib.quote(path)
 
-        conn = None
-
         def unexpected_http_status(response):
-            message = response.read()
+            message = response.data
 
             raise SproxydHTTPException(
                 '%s: %s' % (caller_name, message),
                 ipaddr=address, port=port,
-                path=self.base_path,
+                path=safe_path,
                 http_status=response.status,
                 http_reason=response.reason)
 
-        with swift.common.exceptions.ConnectionTimeout(self.conn_timeout):
-            conn = swift.common.bufferedhttp.http_connect_raw(
-                address, port, method, safe_path, headers)
+        pool = self.http_pools.connection_from_host(address, port)
+        response = None
+        try:
+            response = pool.request(method, safe_path, headers=headers, preload_content=False)
+            handler = handlers.get(response.status, unexpected_http_status)
 
-        with contextlib.closing(conn), eventlet.Timeout(self.proxy_timeout):
-            resp = conn.getresponse()
-            status = resp.status
+            self.logger.debug('The HTTP connection pool to %s:%d serviced %d '
+                              'requests. Its max size ever is %d.', pool.host,
+                              pool.port, pool.num_requests, pool.num_connections)
 
-            handler = handlers.get(status, unexpected_http_status)
-            return handler(resp)
+            return handler(response)
+        finally:
+            if response:
+                response.release_conn()
 
     @utils.trace
     def get_meta(self, name):
@@ -242,6 +254,20 @@ class SproxydFileSystem(object):
         }
 
         return self._do_http('del_object', handlers, 'DELETE', name)
+
+    @utils.trace
+    def get_object(self, name, headers=None):
+        """Connect to sproxyd and get an object."""
+
+        def handle_200_or_206(response):
+            return response.stream(amt=1024 * 64)
+
+        handlers = {
+            200: handle_200_or_206,
+            206: handle_200_or_206
+        }
+
+        return self._do_http('get_object', handlers, 'GET', name, headers)
 
     @utils.trace
     def get_diskfile(self, account, container, obj, **kwargs):
@@ -334,26 +360,11 @@ class DiskFileReader(object):
 
     @property
     def safe_path(self):
-        return self._filesystem.base_path + urllib.quote(self.name)
-
-    @property
-    def name(self):
-        return self._name
+        return self._filesystem.base_path + urllib.quote(self._name)
 
     @utils.trace
     def __iter__(self):
-        (ipaddr, port) = self._filesystem.sproxyd_hosts.next()
-        conn = None
-
-        with swift.common.exceptions.ConnectionTimeout(self._filesystem.conn_timeout):
-            conn = swift.common.bufferedhttp.http_connect_raw(ipaddr, port,
-                                                              'GET',
-                                                              self.safe_path)
-
-        with contextlib.closing(conn):
-            resp = conn.getresponse()
-            for chunk in swift_scality_backend.http_utils.stream(resp):
-                yield chunk
+        return self._filesystem.get_object(self._name)
 
     @utils.trace
     def can_zero_copy_send(self):
@@ -410,19 +421,7 @@ class DiskFileReader(object):
             'range': 'bytes=' + str(start) + '-' + str(stop)
         }
 
-        (ipaddr, port) = self._filesystem.sproxyd_hosts.next()
-        conn = None
-
-        with swift.common.exceptions.ConnectionTimeout(self._filesystem.conn_timeout):
-            conn = swift.common.bufferedhttp.http_connect_raw(ipaddr, port,
-                                                              'GET',
-                                                              self.safe_path,
-                                                              headers)
-
-        with contextlib.closing(conn):
-            resp = conn.getresponse()
-            for chunk in swift_scality_backend.http_utils.stream(resp):
-                yield chunk
+        return self._filesystem.get_object(self._name, headers)
 
     @utils.trace
     def app_iter_ranges(self, ranges, content_type, boundary, size):

--- a/swift_scality_backend/diskfile.py
+++ b/swift_scality_backend/diskfile.py
@@ -199,8 +199,10 @@ class SproxydFileSystem(object):
             try:
                 swift_scality_backend.http_utils.drain_connection(response)
                 response.release_conn()
-            except Exception:
-                pass
+            except Exception as exc:
+                self.logger.error("Unexpected exception while releasing an "
+                                  "HTTP connection to %s:%d: %r", pool.host,
+                                  pool.port, exc)
 
         return result
 

--- a/swift_scality_backend/diskfile.py
+++ b/swift_scality_backend/diskfile.py
@@ -175,7 +175,7 @@ class SproxydFileSystem(object):
         safe_path = self.base_path + urllib.quote(path)
 
         def unexpected_http_status(response):
-            message = response.data
+            message = response.read()
 
             raise SproxydHTTPException(
                 '%s: %s' % (caller_name, message),
@@ -211,7 +211,7 @@ class SproxydFileSystem(object):
             return pickle.loads(pickled)
 
         def handle_404(response):
-            pass
+            return None
 
         handlers = {
             200: handle_200,
@@ -247,7 +247,7 @@ class SproxydFileSystem(object):
         """Connect to sproxyd and delete object."""
 
         def handle_200_or_404(response):
-            pass
+            return None
 
         handlers = {
             200: handle_200_or_404,

--- a/swift_scality_backend/diskfile.py
+++ b/swift_scality_backend/diskfile.py
@@ -185,11 +185,6 @@ class SproxydFileSystem(object):
                 http_reason=response.reason)
 
         response = pool.request(method, safe_path, headers=headers, preload_content=False)
-
-        self.logger.debug('The HTTP connection pool to %s:%d serviced %d '
-                          'requests. Its max size ever is %d.', pool.host,
-                          pool.port, pool.num_requests, pool.num_connections)
-
         handler = handlers.get(response.status, unexpected_http_status)
         result = handler(response)
 
@@ -236,11 +231,8 @@ class SproxydFileSystem(object):
             'x-scal-usermd': base64.b64encode(pickle.dumps(metadata)),
         }
 
-        def handle_200(response):
-            pass
-
         handlers = {
-            200: handle_200,
+            200: lambda _: None,
         }
 
         result = self._do_http('put_meta', handlers, 'PUT', name, headers)

--- a/swift_scality_backend/http_utils.py
+++ b/swift_scality_backend/http_utils.py
@@ -111,5 +111,6 @@ class SomewhatBufferedHTTPConnection(httplib.HTTPConnection):
 
 
 def drain_connection(response):
+    '''Read remaining data of the `Response` to 'clean' underlying socket.'''
     while response.read(64 * 1024):
         pass

--- a/swift_scality_backend/http_utils.py
+++ b/swift_scality_backend/http_utils.py
@@ -15,7 +15,6 @@
 
 '''HTTP client utilities'''
 
-import errno
 import httplib
 import socket
 
@@ -109,28 +108,3 @@ class SomewhatBufferedHTTPConnection(httplib.HTTPConnection):
 
     def __exit__(self, *exc_info):
         self.close()
-
-
-def stream(fp, chunksize=(1024 * 64)):
-    '''Yield blocks of data from a file-like object using a given chunk size
-
-    This generator yield blocks from the given file-like object `fp` by calling
-    its `read` method repeatedly, stopping the loop once a zero-length value is
-    returned.
-
-    Any `OSError` or `IOError` with `errno` equal to `errno.EINTR` will be
-    caught and the loop will continue to run.
-    '''
-    while True:
-        try:
-            chunk = fp.read(chunksize)
-        except (OSError, IOError) as exc:
-            if getattr(exc, 'errno', None) == errno.EINTR:
-                continue
-            else:
-                raise
-
-        if len(chunk) != 0:
-            yield chunk
-        else:
-            break

--- a/swift_scality_backend/http_utils.py
+++ b/swift_scality_backend/http_utils.py
@@ -108,3 +108,8 @@ class SomewhatBufferedHTTPConnection(httplib.HTTPConnection):
 
     def __exit__(self, *exc_info):
         self.close()
+
+
+def drain_connection(response):
+    while response.read(64 * 1024):
+        pass

--- a/swift_scality_backend/utils.py
+++ b/swift_scality_backend/utils.py
@@ -152,6 +152,9 @@ def get_urllib3():
     '''Returns the urllib3 library that matches our requirement.'''
     import urllib3
     if urllib3.__version__ not in REQUIRES['urllib3']:
+        DEFAULT_LOGGER.info("The default python-urllib3 library on this "
+                            "system is not new enough. The one installed from "
+                            "PyPi will be used.")
         for mod in [_ for _ in sys.modules.keys() if _.startswith('urllib3')]:
             del(sys.modules[mod])
         with import_specific(REQUIRES['urllib3']):

--- a/swift_scality_backend/utils.py
+++ b/swift_scality_backend/utils.py
@@ -13,13 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
 import inspect
 import logging
 import functools
 import re
+import sys
 
 import eventlet
+import pkg_resources
 
+import swift_scality_backend
 import swift_scality_backend.afd
 from swift_scality_backend.exceptions import SproxydConfException, \
     InvariantViolation
@@ -30,6 +34,10 @@ DEFAULT_LOGGER = logging.getLogger(__name__)
 # format is JSON (Ring 5+) or INI (Ring 4)
 BY_PATH_ENABLED_RE = re.compile(r'^\s*"?by_path_enabled[":=]+\s*(1|true)[",]*\s*$',
                                 flags=re.IGNORECASE)
+
+# A Dict which values are `pkg_resources.Requirement` objects
+REQUIRES = {req.project_name: req for req in pkg_resources.parse_requirements(
+            swift_scality_backend.__requires__)}
 
 
 def trace(f):
@@ -118,3 +126,35 @@ def is_sproxyd_conf_valid(conf):
 
     raise SproxydConfException("Make sure by_path_enabled is set "
                                "and check Sproxyd logs.")
+
+
+@contextlib.contextmanager
+def import_specific(*requirements):
+    '''Temporarily change import path to satisfy some requirements.
+
+    `requirements` can be strings or `pkg_resources.Requirement` objects,
+    specifying the distributions and versions required.
+    '''
+    saved_sys_path = list(sys.path)
+    path_to_add = set()
+    for requirement in requirements:
+        distribution = pkg_resources.get_distribution(requirement)
+        path_to_add.add(distribution.location)
+    for path in path_to_add:
+        sys.path.insert(0, path)
+    try:
+        yield
+    finally:
+        sys.path[:] = saved_sys_path
+
+
+def get_urllib3():
+    '''Returns the urllib3 library that matches our requirement.'''
+    import urllib3
+    if urllib3.__version__ not in REQUIRES['urllib3']:
+        for mod in [_ for _ in sys.modules.keys() if _.startswith('urllib3')]:
+            del(sys.modules[mod])
+        with import_specific(REQUIRES['urllib3']):
+            import urllib3
+
+    return urllib3

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,3 +6,4 @@ nosexcover
 openstack.nose_plugin
 nosehtmloutput
 mock>=1.0
+urllib3>=1.9,<2.0

--- a/test/unit/test_diskfile.py
+++ b/test/unit/test_diskfile.py
@@ -20,15 +20,20 @@ import itertools
 import httplib
 import pickle
 import StringIO
+import socket
 import unittest
 import urllib
 import weakref
 
 
 import eventlet
+eventlet.monkey_patch()
+import eventlet.wsgi
 import mock
 import swift.common.exceptions
 import swift.common.utils
+import urllib3
+import urllib3.exceptions
 
 NEW_SPLICE = 'new_splice'
 OLD_SPLICE = 'old_splice'
@@ -54,9 +59,6 @@ class FakeHTTPResp(httplib.HTTPResponse):
     def __init__(self, status=200):
         self.status = status
         self.reason = 'because'
-        usermd = base64.b64encode(pickle.dumps('fake'))
-        headers = StringIO.StringIO('x-scal-usermd: %s' % usermd)
-        self.msg = httplib.HTTPMessage(headers)
 
     def read(self):
         return 'My mock msg'
@@ -165,10 +167,9 @@ class TestSproxydFileSystem(unittest.TestCase):
     def test_init_no_splice_at_all(self):
         self._test_init_splice_unavailable()
 
-    @mock.patch.object(urllib, 'urlopen')
-    @mock.patch('swift_scality_backend.utils.is_sproxyd_conf_valid',
+    @mock.patch('urllib3.PoolManager.request',
                 side_effect=SproxydConfException(""))
-    def test_ping_with_bad_sproxyd_conf(self, conf_checker_mock, urlopen_mock):
+    def test_ping_with_bad_sproxyd_conf(self, request_mock):
         mock_logger = mock.Mock()
         sfs = SproxydFileSystem({}, mock_logger)
         ping_result = sfs.ping('http://ignored')
@@ -179,7 +180,7 @@ class TestSproxydFileSystem(unittest.TestCase):
         self.assertIs(type(exc), SproxydConfException)
         self.assertIn("is invalid:", msg)
 
-    @mock.patch.object(urllib, 'urlopen', side_effect=Exception)
+    @mock.patch('urllib3.PoolManager.request', side_effect=Exception)
     def test_ping_with_unexpected_exc(self, urlopen_mock):
         mock_logger = mock.Mock()
         sfs = SproxydFileSystem({}, mock_logger)
@@ -207,40 +208,46 @@ class TestSproxydFileSystem(unittest.TestCase):
         self.assertNotIn(('localhost', 81), sfs.sproxyd_hosts_set)
         self.assertEqual([], list(sfs.sproxyd_hosts))
 
-    @mock.patch('swift.common.bufferedhttp.http_connect_raw',
-                side_effect=lambda *args: eventlet.sleep(0.02))
+    @mock.patch('socket.socket.connect', side_effect=socket.timeout)
     def test_do_http_connection_timeout(self, mock_http_connect):
-        sfs = SproxydFileSystem({'sproxyd_conn_timeout': 0.01}, mock.Mock())
-        self.assertRaises(swift.common.exceptions.ConnectionTimeout,
-                          sfs._do_http, 'me', {}, 'HTTP_METH', '/')
+        timeout = 0.01
+        sfs = SproxydFileSystem({'sproxyd_conn_timeout': timeout}, mock.Mock())
+
+        regex = r'^.*connect timeout=%s.*$' % timeout
+        self.assertRaisesRegexp(urllib3.exceptions.ConnectTimeoutError, regex,
+                                sfs._do_http, 'me', {}, 'HTTP_METH', '/')
 
     def test_do_http_timeout(self):
-        class HTTPConn(object):
+        server1 = eventlet.listen(('127.0.0.1', 0))
+        (ip, port) = server1.getsockname()
 
-            def getresponse(self):
-                eventlet.sleep(0.02)
+        def run_server1(sock):
+            (client, addr) = sock.accept()
+            eventlet.sleep(0.1)
 
-            def close(self):
-                pass
+        t = eventlet.spawn(run_server1, server1)
+        timeout = 0.01
+        sfs = SproxydFileSystem({'sproxyd_host': '%s:%d' % (ip, port),
+                                 'sproxyd_proxy_timeout': timeout},
+                                mock.Mock())
 
-        sfs = SproxydFileSystem({'sproxyd_proxy_timeout': 0.01}, mock.Mock())
+        regex = r'^.*read timeout=%s.*$' % timeout
+        self.assertRaisesRegexp(urllib3.exceptions.ReadTimeoutError, regex,
+                                sfs._do_http, 'me', {}, 'HTTP_METH', '/')
+        t.kill()
 
-        with mock.patch('swift.common.bufferedhttp.http_connect_raw',
-                        return_value=HTTPConn()):
-            self.assertRaises(eventlet.Timeout, sfs._do_http, 'me',
-                              {}, 'HTTP_METH', '/')
-
-    @mock.patch('swift.common.bufferedhttp.http_connect_raw',
-                return_value=FakeHTTPConn())
+    @mock.patch('urllib3.HTTPConnectionPool.request',
+                return_value=urllib3.response.HTTPResponse(body='error',
+                                                           status=500))
     def test_do_http_unexpected_http_status(self, mock_http):
         sfs = SproxydFileSystem({}, mock.Mock())
 
-        msg = r'caller1: %s .*' % mock_http.return_value.getresponse().read()
+        msg = r'^caller1: %s .*' % mock_http.return_value.data
         self.assertRaisesRegexp(SproxydHTTPException, msg, sfs._do_http,
                                 'caller1', {}, 'HTTP_METH', '/')
 
-    @mock.patch('swift.common.bufferedhttp.http_connect_raw',
-                return_value=FakeHTTPConn())
+    @mock.patch('urllib3.HTTPConnectionPool.request',
+                return_value=urllib3.response.HTTPResponse(status=200))
     def test_do_http(self, mock_http):
         mock_handler = mock.Mock()
 
@@ -251,40 +258,47 @@ class TestSproxydFileSystem(unittest.TestCase):
         headers = {'k': 'v'}
         sfs._do_http('caller1', {200: mock_handler}, method, path, headers)
 
-        mock_http.assert_called_with(mock.ANY, mock.ANY, method,
-                                     sfs.base_path + urllib.quote(path),
-                                     headers)
-        call_args = mock_handler.call_args
-        self.assertIsNotNone(call_args)
-        expected_arg = mock_http.return_value.getresponse()
-        self.assertIsInstance(call_args[0][0], type(expected_arg))
+        mock_http.assert_called_once_with(method,
+                                          sfs.base_path + urllib.quote(path),
+                                          headers=headers,
+                                          preload_content=False)
+        mock_handler.assert_called_once_with(mock_http.return_value)
 
-    @mock.patch('swift.common.bufferedhttp.http_connect_raw',
-                return_value=FakeHTTPConn())
-    def test_get_meta(self, mock_http):
+    @mock.patch('urllib3.HTTPConnectionPool.request')
+    def test_get_meta_on_200(self, mock_http):
+        headers = {'x-scal-usermd': base64.b64encode(pickle.dumps('fake'))}
+        mock_http.return_value = urllib3.response.HTTPResponse(status=200,
+                                                               headers=headers)
+
         sfs = SproxydFileSystem({}, mock.Mock())
         metadata = sfs.get_meta('object_name_1')
 
-        self.assertEqual(1, mock_http.call_count)
-        mock_http.assert_called_with(mock.ANY, mock.ANY, 'HEAD',
-                                     sfs.base_path + 'object_name_1',
-                                     None)
+        mock_http.assert_called_once_with('HEAD',
+                                          sfs.base_path + 'object_name_1',
+                                          headers=None, preload_content=False)
         self.assertEqual('fake', metadata)
 
-    @mock.patch('swift.common.bufferedhttp.http_connect_raw',
-                return_value=FakeHTTPConn())
+    @mock.patch('urllib3.HTTPConnectionPool.request',
+                return_value=urllib3.response.HTTPResponse(status=404))
+    def test_get_meta_on_404(self, mock_http):
+        sfs = SproxydFileSystem({}, mock.Mock())
+
+        self.assertIsNone(sfs.get_meta('object_name_1'))
+
+    @mock.patch('urllib3.HTTPConnectionPool.request',
+                return_value=urllib3.response.HTTPResponse(status=200))
     def test_put_meta(self, mock_http):
         sfs = SproxydFileSystem({}, mock.Mock())
         sfs.put_meta('object_name_1', 'fake')
 
         self.assertEqual(1, mock_http.call_count)
-        (ip, port, method, path, headers), kwargs = mock_http.call_args
+        (method, path), kwargs = mock_http.call_args
         self.assertEqual('PUT', method)
         self.assertIn('object_name_1', path)
-        self.assertIn('x-scal-cmd', headers)
-        self.assertEqual('update-usermd', headers['x-scal-cmd'])
-        self.assertIn('x-scal-usermd', headers)
-        self.assertGreater(len(headers['x-scal-usermd']), 0)
+        self.assertIn('x-scal-cmd', kwargs['headers'])
+        self.assertEqual('update-usermd', kwargs['headers']['x-scal-cmd'])
+        self.assertIn('x-scal-usermd', kwargs['headers'])
+        self.assertGreater(len(kwargs['headers']['x-scal-usermd']), 0)
 
     def test_put_meta_with_no_metadata(self):
         sfs = SproxydFileSystem({}, mock.Mock())
@@ -292,16 +306,33 @@ class TestSproxydFileSystem(unittest.TestCase):
         self.assertRaisesRegexp(SproxydHTTPException, 'no usermd',
                                 sfs.put_meta, 'object_name_1', None)
 
-    @mock.patch('swift.common.bufferedhttp.http_connect_raw',
-                return_value=FakeHTTPConn())
+    @mock.patch('urllib3.HTTPConnectionPool.request',
+                return_value=urllib3.response.HTTPResponse(status=200))
     def test_del_object(self, mock_http):
         sfs = SproxydFileSystem({}, mock.Mock())
         sfs.del_object('object_name_1')
 
-        self.assertEqual(1, mock_http.call_count)
-        mock_http.assert_called_with(mock.ANY, mock.ANY, 'DELETE',
-                                     sfs.base_path + 'object_name_1',
-                                     None)
+        mock_http.assert_called_once_with('DELETE',
+                                          sfs.base_path + 'object_name_1',
+                                          headers=None, preload_content=False)
+
+    def test_get_object(self):
+        server = eventlet.listen(('127.0.0.1', 0))
+        (ip, port) = server.getsockname()
+
+        def hello_world(env, start_response):
+            start_response('200 OK', [('Content-Type', 'text/plain')])
+            return ['Hello, World!\r\n']
+
+        t = eventlet.spawn(eventlet.wsgi.server, server, hello_world)
+
+        sfs = SproxydFileSystem({'sproxyd_host': '%s:%d' % (ip, port)},
+                                mock.Mock())
+        obj = sfs.get_object('ignored')
+
+        self.assertEqual('Hello, World!\r\n', next(obj))
+        self.assertRaises(StopIteration, next, obj)
+        t.kill()
 
     @mock.patch('eventlet.spawn')
     def test_del_instance(self, mock_spawn):
@@ -318,6 +349,10 @@ class TestSproxydFileSystem(unittest.TestCase):
 
         mock_spawn().kill.assert_called_once_with()
 
+    def test_get_diskfile(self):
+        sfs = SproxydFileSystem({}, mock.Mock())
+        self.assertIsInstance(sfs.get_diskfile('a', 'c', 'o'), DiskFile)
+
 
 class TestDiskFileWriter(unittest.TestCase):
     """Tests for swift_scality_backend.diskfile.DiskFileWriter"""
@@ -329,11 +364,10 @@ class TestDiskFileWriter(unittest.TestCase):
         # Note the white space, to test proper URL encoding
         DiskFileWriter(sfs, 'ob j')
 
-        self.assertEqual(1, mock_http.call_count)
         expected_header = {'transfer-encoding': 'chunked'}
-        mock_http.assert_called_with(mock.ANY, mock.ANY, 'PUT',
-                                     sfs.base_path + urllib.quote('ob j'),
-                                     expected_header)
+        mock_http.assert_called_once_with(mock.ANY, mock.ANY, 'PUT',
+                                          sfs.base_path + urllib.quote('ob j'),
+                                          expected_header)
 
     @mock.patch('swift.common.bufferedhttp.http_connect_raw',
                 return_value=FakeHTTPConn(404))
@@ -418,8 +452,7 @@ class TestDiskFile(unittest.TestCase):
 
         df.write_metadata({'k': 'v'})
 
-        self.assertEqual(1, mock_put_meta.call_count)
-        mock_put_meta.assert_called_with('a/c/o', {'k': 'v'})
+        mock_put_meta.assert_called_once_with('a/c/o', {'k': 'v'})
 
     @mock.patch('swift_scality_backend.diskfile.SproxydFileSystem.del_object')
     def test_delete(self, mock_del_object):
@@ -428,8 +461,7 @@ class TestDiskFile(unittest.TestCase):
 
         df.delete("ignored")
 
-        self.assertEqual(1, mock_del_object.call_count)
-        mock_del_object.assert_called_with('a/c/o')
+        mock_del_object.assert_called_once_with('a/c/o')
 
 
 def test_ping_when_network_exception_is_raised():
@@ -438,7 +470,7 @@ def test_ping_when_network_exception_is_raised():
         logger = mock.Mock()
         filesystem = SproxydFileSystem({}, logger)
 
-        with mock.patch.object(urllib, 'urlopen', side_effect=expected_exc):
+        with mock.patch('urllib3.PoolManager.request', side_effect=expected_exc):
             ping_result = filesystem.ping('http://ignored/')
 
             assert ping_result is False, ('Ping returned %r, '
@@ -448,5 +480,5 @@ def test_ping_when_network_exception_is_raised():
             assert type(exc) is expected_exc
             assert "network error" in msg
 
-    for exc in [eventlet.Timeout, httplib.HTTPException, IOError]:
+    for exc in [IOError, urllib3.exceptions.HTTPError]:
         yield assert_ping_failed, exc

--- a/test/unit/test_diskfile.py
+++ b/test/unit/test_diskfile.py
@@ -332,9 +332,9 @@ class TestSproxydFileSystem(unittest.TestCase):
                                 mock.Mock())
         obj = sfs.get_object('ignored')
 
-        self.assertEqual(content, ''.join(obj))
+        self.assertEqual(content, obj.next())
         # Assert that `obj` is an Iterable
-        self.assertRaises(StopIteration, obj.next())
+        self.assertRaises(StopIteration, obj.next)
         t.kill()
 
     @mock.patch('eventlet.spawn')

--- a/test/unit/test_diskfile.py
+++ b/test/unit/test_diskfile.py
@@ -27,7 +27,6 @@ import weakref
 
 
 import eventlet
-eventlet.monkey_patch()
 import eventlet.wsgi
 import mock
 import swift.common.exceptions
@@ -52,6 +51,8 @@ from swift_scality_backend.diskfile import SproxydFileSystem, DiskFileWriter, \
     DiskFileReader, DiskFile
 from swift_scality_backend.exceptions import SproxydConfException, \
     SproxydHTTPException
+
+eventlet.monkey_patch()
 
 
 class FakeHTTPResp(httplib.HTTPResponse):

--- a/test/unit/test_diskfile.py
+++ b/test/unit/test_diskfile.py
@@ -308,10 +308,11 @@ class TestSproxydFileSystem(unittest.TestCase):
         (method, path), kwargs = mock_http.call_args
         self.assertEqual('PUT', method)
         self.assertIn('object_name_1', path)
-        self.assertIn('x-scal-cmd', kwargs['headers'])
-        self.assertEqual('update-usermd', kwargs['headers']['x-scal-cmd'])
-        self.assertIn('x-scal-usermd', kwargs['headers'])
-        self.assertGreater(len(kwargs['headers']['x-scal-usermd']), 0)
+        headers = kwargs['headers']
+        self.assertIn('x-scal-cmd', headers)
+        self.assertEqual('update-usermd', headers['x-scal-cmd'])
+        self.assertIn('x-scal-usermd', headers)
+        self.assertGreater(len(headers['x-scal-usermd']), 0)
 
     def test_put_meta_with_no_metadata(self):
         sfs = SproxydFileSystem({}, mock.Mock())

--- a/test/unit/test_diskfile.py
+++ b/test/unit/test_diskfile.py
@@ -320,9 +320,11 @@ class TestSproxydFileSystem(unittest.TestCase):
         server = eventlet.listen(('127.0.0.1', 0))
         (ip, port) = server.getsockname()
 
+        content = 'Hello, World!'
+
         def hello_world(env, start_response):
             start_response('200 OK', [('Content-Type', 'text/plain')])
-            return ['Hello, World!\r\n']
+            return [content]
 
         t = eventlet.spawn(eventlet.wsgi.server, server, hello_world)
 
@@ -330,8 +332,9 @@ class TestSproxydFileSystem(unittest.TestCase):
                                 mock.Mock())
         obj = sfs.get_object('ignored')
 
-        self.assertEqual('Hello, World!\r\n', next(obj))
-        self.assertRaises(StopIteration, next, obj)
+        self.assertEqual(content, ''.join(obj))
+        # Assert that `obj` is an Iterable
+        self.assertRaises(StopIteration, obj.next())
         t.kill()
 
     @mock.patch('eventlet.spawn')

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -124,7 +124,7 @@ class TestMonitoringLoop(unittest.TestCase):
         ping = mock.Mock(side_effect=cycle)
 
         thread = eventlet.spawn(functools.partial(self.loop, ping))
-        eventlet.sleep(0.1)
+        eventlet.sleep(0.2)
         try:
             self.assertGreaterEqual(ping.call_count, 5)
             # We've slept for a time long enough to see several (>=3 even

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -125,7 +125,7 @@ class TestMonitoringLoop(unittest.TestCase):
         ping = mock.Mock(side_effect=cycle)
 
         thread = eventlet.spawn(functools.partial(self.loop, ping))
-        eventlet.sleep(0.2)
+        eventlet.sleep(0.1)
         try:
             self.assertGreaterEqual(ping.call_count, 5)
             # We've slept for a time long enough to see several (>=3 even

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -17,6 +17,7 @@
 
 import functools
 import itertools
+import types
 import unittest
 
 import eventlet
@@ -137,3 +138,8 @@ class TestMonitoringLoop(unittest.TestCase):
             self.assertLessEqual(abs(diff), 1)
         finally:
             thread.kill()
+
+
+def test_get_urllib3():
+    urllib3 = utils.get_urllib3()
+    assert isinstance(urllib3, types.ModuleType)


### PR DESCRIPTION
The `DiskFileWriter` and `DiskFileReader::zero_copy_send` still
use non pooled HTTP connection.

Closes #37