### PR TITLE
Add a py26-1.13 tox target

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
-envlist = py27-swift1.13.1,py27-swift2.2.0,pep8
+envlist = py26-swift1.13.1,py27-swift1.13.1,py27-swift2.2.0,pep8
 minversion = 1.8.1
 
 [testenv]
-basepython = python2.7
 deps =
     swift1.13.1: https://launchpad.net/swift/icehouse/1.13.1/+download/swift-1.13.1.tar.gz
     swift2.0.0: https://launchpad.net/swift/juno/2.0.0/+download/swift-2.0.0.tar.gz


### PR DESCRIPTION
This needs an executable named python2.6 in $PATH. For Ubuntu based
system, this PPA has been tested : ppa:fkrull/deadsnakes