### PR TITLE
Work-around missing Git repository during Tox runs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,18 +14,38 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import distutils.spawn
 import setuptools
 import subprocess
 
+
 def get_version():
-    prefix = 'swift-scality-backend-'
-    cmd = ['git', 'describe', '--tags', '--dirty', '--always',
-           '--match', '%s*' % prefix]
+    def has_git():
+        return distutils.spawn.find_executable('git') is not None
 
-    result = subprocess.check_output(cmd).strip()
-    assert result.startswith(prefix)
+    def is_git_clone():
+        cmd = ['git', 'rev-parse', '--show-toplevel']
 
-    return result[len(prefix):]
+        proc = subprocess.Popen(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+        return proc.wait() == 0
+
+    def get_git_version():
+        prefix = 'swift-scality-backend-'
+        cmd = ['git', 'describe', '--tags', '--dirty', '--always',
+               '--match', '%s*' % prefix]
+
+        result = subprocess.check_output(cmd).strip()
+        assert result.startswith(prefix)
+
+        return result[len(prefix):]
+
+    if has_git() and is_git_clone():
+        return get_git_version()
+    else:
+        return '999'
+
 
 setuptools.setup(
     name='swift-scality-backend',


### PR DESCRIPTION
The changes introduced in 00a95a87 broke `tox` runs because these rely
on source packages. This commit works around by supporting non-Git
trees, setting the version to '999' unconditionally.

See: 00a95a87cee314fe25df41dc039dc09de794a91f