### PR TITLE
Increase the sleep time in `test_monitoring_loop_with_ping_flapping`

### DIFF
--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -125,7 +125,7 @@ class TestMonitoringLoop(unittest.TestCase):
         ping = mock.Mock(side_effect=cycle)
 
         thread = eventlet.spawn(functools.partial(self.loop, ping))
-        eventlet.sleep(0.1)
+        eventlet.sleep(0.2)
         try:
             self.assertTrue(ping.call_count >= 5)
             # We've slept for a time long enough to see several (>=3 even


### PR DESCRIPTION
This value is arbitrarily set but should be long enough to let
the failure detector detects the host went down and up again several
times.

The previous value, 0.1 sec, was not enough.