### PR TITLE
Add py26-swift2.2.0 target.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26-swift1.13.1,py26-swift2.2.0,py27-swift1.13.1,py27-swift2.2.0,pep8
+envlist = py{26,27}-swift{1.13.1,2.1.0,2.2.0,head},pep8
 minversion = 1.8.1
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26-swift1.13.1,py27-swift1.13.1,py27-swift2.2.0,pep8
+envlist = py26-swift1.13.1,py26-swift2.2.0,py27-swift1.13.1,py27-swift2.2.0,pep8
 minversion = 1.8.1
 
 [testenv]


### PR DESCRIPTION
Actually I don't understand why is that even necessary : the 'py**-swifthead' are not even on that list, still these envs can be setup by jenkins.

Actually I might clean that a little bit using http://tox.readthedocs.org/en/latest/example/basic.html#compressing-dependency-matrix