### PR TITLE
Implement storage policy configuration lint and query tool

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,5 +79,7 @@ setuptools.setup(
     entry_points={
         'paste.app_factory': [
             'sproxyd_object=swift_scality_backend.server:app_factory'],
+        'console_scripts': [
+            'swift-scality-backend=swift_scality_backend.cli:main'],
     },
 )

--- a/swift_scality_backend/cli.py
+++ b/swift_scality_backend/cli.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2015 Scality
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''Command-line utilities.'''
+
+import argparse
+import ConfigParser
+import pkg_resources
+import sys
+
+from swift_scality_backend.policy_configuration import Configuration
+from swift_scality_backend.policy_configuration import ConfigurationError
+from swift_scality_backend.policy_configuration import \
+    DEFAULT_CONFIGURATION_PATH
+from swift_scality_backend.policy_configuration import StoragePolicy
+
+
+def print_error(prefix, exn):
+    '''Generic exception message printer.'''
+
+    sys.stderr.write('%s: %s\n' % (prefix, exn.message))
+
+
+def storage_policy_lint(args):
+    '''Implementation of the 'storage-policy-lint' subcommand.'''
+
+    try:
+        Configuration.from_stream(args.config)
+        return 0
+    except ConfigurationError as exn:
+        print_error('Configuration error', exn)
+    except ConfigParser.Error as exn:
+        print_error('Parsing error', exn)
+    except Exception as exn:
+        print_error('Error', exn)
+
+    return 1
+
+
+def storage_policy_query(args):
+    '''Implementation of the 'storage-policy-query' subcommand.'''
+
+    try:
+        config = Configuration.from_stream(args.config)
+        policy = config.get_policy(args.policy_index)
+    except Exception as exn:
+        print_error('Error', exn)
+        return 1
+
+    print 'Query'
+    print '-----'
+    print 'Policy index:', args.policy_index
+    print 'Action:', args.action
+    print 'Location hints:', args.locations
+    print
+
+    print 'Result'
+    print '------'
+    result = policy.lookup(args.action, args.locations)
+    for (idx, endpoints) in enumerate(result):
+        print '%d: %r' % (idx, list(sorted(str(e) for e in endpoints)))
+
+    return 0
+
+
+def main(args=None):
+    '''Main entry point.'''
+
+    parser = argparse.ArgumentParser(
+        description='Scality Swift back-end utilities')
+    subparsers = parser.add_subparsers(
+        title='subcommands')
+
+    try:
+        package = pkg_resources.get_distribution('swift-scality-backend')
+        version = '%s %s' % (package.project_name, package.version)
+    except pkg_resources.DistributionNotFound:
+        version = 'unknown'
+
+    parser.add_argument('--version', action='version', version=version)
+
+    # storage-policy-lint parser
+    parser_sp_lint = subparsers.add_parser('storage-policy-lint')
+    parser_sp_lint.set_defaults(func=storage_policy_lint)
+    parser_sp_lint.add_argument(
+        '-c', '--config',
+        dest='config', action='store', type=argparse.FileType('r'),
+        help='storage policy configuration to lint', metavar='FILE',
+        default=DEFAULT_CONFIGURATION_PATH)
+
+    # storage-policy-query parser
+    parser_sp_query = subparsers.add_parser('storage-policy-query')
+    parser_sp_query.set_defaults(func=storage_policy_query)
+    parser_sp_query.add_argument(
+        '-c', '--config',
+        dest='config', action='store', type=argparse.FileType('r'),
+        help='storage policy configuration to query', metavar='FILE',
+        default=DEFAULT_CONFIGURATION_PATH)
+    parser_sp_query.add_argument(
+        'action',
+        choices=[StoragePolicy.READ, StoragePolicy.WRITE],
+        help='action to emulate', metavar='ACTION')
+    parser_sp_query.add_argument(
+        'policy_index',
+        action='store', type=int,
+        help='storage policy index', metavar='INDEX')
+    parser_sp_query.add_argument(
+        'locations',
+        help='location hints', metavar='LOCATION',
+        nargs='*')
+
+    # Go
+    args2 = parser.parse_args(args=args)
+    rc = args2.func(args2)
+
+    sys.exit(rc)
+
+
+if __name__ == '__main__':
+    main()

--- a/swift_scality_backend/cli.py
+++ b/swift_scality_backend/cli.py
@@ -15,7 +15,10 @@
 
 '''Command-line utilities.'''
 
-import argparse
+try:
+    import argparse
+except ImportError:
+    argparse = None
 import ConfigParser
 import pkg_resources
 import sys
@@ -77,6 +80,13 @@ def storage_policy_query(args):
 
 def main(args=None):
     '''Main entry point.'''
+
+    if not argparse:
+        if sys.version_info < (2, 7):
+            sys.stderr.write('This tool requires `argparse` or Python 2.7\n')
+            sys.exit(2)
+        else:
+            raise ImportError('No module named argparse')
 
     parser = argparse.ArgumentParser(
         description='Scality Swift back-end utilities')

--- a/swift_scality_backend/policy_configuration.py
+++ b/swift_scality_backend/policy_configuration.py
@@ -19,9 +19,16 @@ Structures and procedures to handle Swift storage policy configuration files.
 
 import ConfigParser
 import operator
+import os.path
 import urlparse
 
+import swift.common.manager
+
 from swift_scality_backend import utils
+
+
+DEFAULT_CONFIGURATION_PATH = os.path.join(
+    swift.common.manager.SWIFT_DIR, 'scality-storage-policies.ini')
 
 
 class Endpoint(object):  # pylint: disable=R0903

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -1,0 +1,195 @@
+# Copyright (c) 2015 Scality
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''Tests for `swift_scality_backend.cli`.'''
+
+import unittest
+import sys
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from StringIO import StringIO
+
+from swift_scality_backend import cli
+from swift_scality_backend.policy_configuration import StoragePolicy
+
+
+class FakeStream(object):
+    def __init__(self, module, attr):
+        self.stream = StringIO()
+        self._module = module
+        self._attr = attr
+        self._orig_attr = None
+
+    def __enter__(self):
+        self._orig_attr = getattr(self._module, self._attr)
+        setattr(self._module, self._attr, self.stream)
+
+        return self
+
+    def __exit__(self, exc, value, tb):
+        setattr(self._module, self._attr, self._orig_attr)
+
+
+class Namespace(object):
+    def __init__(self, **kwargs):
+        for (name, value) in kwargs.iteritems():
+            setattr(self, name, value)
+
+
+class TestStoragePolicyLint(unittest.TestCase):
+    def test_lint_fails_on_malformed_file(self):
+        config = 'test'
+
+        args = Namespace(
+            config=StringIO(config))
+
+        with FakeStream(sys, 'stderr') as stderr:
+            rc = cli.storage_policy_lint(args)
+
+            self.assertRegexpMatches(
+                stderr.stream.getvalue(),
+                'Parsing error:')
+
+            self.assertNotEqual(0, rc)
+
+    def test_lint_fails_on_invalid_config(self):
+        config = '[ring:]'
+
+        args = Namespace(
+            config=StringIO(config))
+
+        with FakeStream(sys, 'stderr') as stderr:
+            rc = cli.storage_policy_lint(args)
+
+            self.assertRegexpMatches(
+                stderr.stream.getvalue(),
+                'Configuration error:')
+
+            self.assertNotEqual(0, rc)
+
+    def test_lint_fails_on_exception(self):
+        class Stream(object):
+            def readline(self):
+                raise IOError('Oops')
+
+        args = Namespace(
+            config=Stream())
+
+        with FakeStream(sys, 'stderr') as stderr:
+            rc = cli.storage_policy_lint(args)
+
+            self.assertRegexpMatches(
+                stderr.stream.getvalue(),
+                'Error: Oops')
+
+            self.assertNotEqual(0, rc)
+
+    def test_lint_succeeds_on_valid_config(self):
+        config = ''
+
+        args = Namespace(
+            config=StringIO(config))
+
+        rc = cli.storage_policy_lint(args)
+
+        self.assertEquals(0, rc)
+
+
+class TestStoragePolicyQuery(unittest.TestCase):
+    def test_load_fails(self):
+        config = '[ring:]'
+
+        args = Namespace(
+            config=StringIO(config))
+
+        with FakeStream(sys, 'stderr') as stderr:
+            rc = cli.storage_policy_query(args)
+
+            self.assertRegexpMatches(
+                stderr.stream.getvalue(),
+                'Error: Invalid section name')
+
+            self.assertNotEqual(0, rc)
+
+    def test_lookup_fails(self):
+        config = ''
+
+        args = Namespace(
+            config=StringIO(config),
+            policy_index=1)
+
+        with FakeStream(sys, 'stderr') as stderr:
+            rc = cli.storage_policy_query(args)
+
+            self.assertRegexpMatches(
+                stderr.stream.getvalue(),
+                'Error: Unknown policy index')
+
+            self.assertNotEqual(0, rc)
+
+    def test_success(self):
+        config = '\n'.join(s.strip() for s in '''
+            [ring:paris]
+            location = paris
+            sproxyd_endpoints = http://paris1.int/, http://paris2.int
+
+            [ring:sfo]
+            location = sfo
+            sproxyd_endpoints = http://sfo1.int
+
+            [storage-policy:2]
+            read = sfo
+            write = paris
+            '''.splitlines())
+
+        args = Namespace(
+            config=StringIO(config),
+            policy_index=2,
+            action=StoragePolicy.WRITE,
+            locations=['paris'])
+
+        with FakeStream(sys, 'stdout') as stdout:
+            rc = cli.storage_policy_query(args)
+
+            self.assertEqual(0, rc)
+
+            out = stdout.stream.getvalue()
+
+            self.assertIn('http://paris1.int', out)
+            self.assertIn('http://paris2.int', out)
+
+            self.assertNotIn('sfo', out)
+
+
+class TestMain(unittest.TestCase):
+    def test_main(self):
+        def exit(code):
+            raise SystemExit(code)
+
+        orig_exit = sys.exit
+        sys.exit = exit
+
+        try:
+            with FakeStream(sys, 'stdout') as stdout:
+                self.assertRaises(
+                    SystemExit,
+                    cli.main, ['--help'])
+
+                self.assertRegexpMatches(
+                    stdout.stream.getvalue(),
+                    'storage-policy-lint')
+        finally:
+            sys.exit = orig_exit

--- a/test/unit/utils.py
+++ b/test/unit/utils.py
@@ -55,3 +55,15 @@ def assertRaisesRegexp(expected_exception, expected_regexp,
         else:
             excName = str(expected_exception)
         raise unittest.TestCase.failureException("%s not raised" % excName)
+
+
+def assertRegexpMatches(text, expected_regexp, msg=None):
+    '''Asserts the text matches the regular expression.'''
+
+    if isinstance(expected_regexp, basestring):
+        expected_regexp = re.compile(expected_regexp)
+
+    if not expected_regexp.search(text):
+        msg = msg or "Regexp didn't match"
+        msg = '%s: %r not found in %r' % (msg, expected_regexp.pattern, text)
+        raise unittest.TestCase.failureException(msg)


### PR DESCRIPTION
Lint valid file:
```
$ swift-scality-backend storage-policy-lint --config scality-storage-policy.ini
$ echo $?
0
```

Query valid file:
```
$ swift-scality-backend storage-policy-query --config scality-storage-policy.ini read 1 sfo paris
Query
-----
Policy index: 1
Action: read
Location hints: ['sfo', 'paris']

Result
------
0: ['http://sfo1.int/arc6+3']
1: ['http://paris1.int/arc6+3', 'http://paris2.int/arc6+3']
```

Lint invalid file:
```
$ echo '[ring:invalid]' | swift-scality-backend storage-policy-lint -c -
Configuration error: Section 'ring:invalid' lacks a 'location' setting
$ echo $?
1
```

Default configuration file is `SWIFT_DIR/scality-storage-policies.ini`.