### PR TITLE
Discard the 'buffering' argument when instantiating an HTTPResponse on python 2.6.

### DIFF
--- a/swift_scality_backend/http_utils.py
+++ b/swift_scality_backend/http_utils.py
@@ -18,6 +18,7 @@
 import errno
 import httplib
 import socket
+import sys
 
 from swift_scality_backend.exceptions import InvariantViolation
 
@@ -93,9 +94,18 @@ class SomewhatBufferedHTTPConnection(httplib.HTTPConnection):
         '''
         def __init__(self, sock, debuglevel=0, strict=0, method=None,
                      buffering=False):
-            httplib.HTTPResponse.__init__(self, sock, debuglevel=debuglevel,
-                                          strict=strict, method=method,
-                                          buffering=buffering)
+            init_args = {
+                'sock': sock,
+                'debuglevel': debuglevel,
+                'strict': strict,
+                'method': method,
+            }
+            if sys.version_info >= (2, 7):
+                init_args.update({
+                    'buffering': buffering,
+                })
+
+            httplib.HTTPResponse.__init__(self, **init_args)
 
             # Fetching in chunks of 1024 bytes seems like a sensible value,
             # since we want to retrieve as little more than the HTTP headers as

--- a/test/unit/test_http_utils.py
+++ b/test/unit/test_http_utils.py
@@ -18,9 +18,11 @@
 import contextlib
 import os
 import socket
+import sys
 import unittest
 
 import eventlet
+import mock
 
 import swift_scality_backend.http_utils
 
@@ -116,3 +118,21 @@ class TestSomewhatBufferedFileObject(unittest.TestCase):
                 self.assertEqual(''.join(rest), data[off:])
         finally:
             server_thread.kill()
+
+
+class TestSomewhatBufferedHTTPConnection(unittest.TestCase):
+
+    def test_discard_buffering_arg_on_py26(self):
+        with mock.patch('httplib.HTTPResponse.__init__') \
+                as mock_http_response_init:
+            kwargs = dict(
+                sock=None, debuglevel=0, strict=0, method=None, buffering=False)
+
+            response_class = \
+                swift_scality_backend.http_utils.SomewhatBufferedHTTPConnection.HTTPResponse
+            response_obj = response_class(**kwargs)
+
+            if sys.version_info < (2, 7):
+                del kwargs['buffering']
+            mock_http_response_init.assert_called_once_with(
+                response_obj, **kwargs)

--- a/test/unit/test_http_utils.py
+++ b/test/unit/test_http_utils.py
@@ -122,17 +122,19 @@ class TestSomewhatBufferedFileObject(unittest.TestCase):
 
 class TestSomewhatBufferedHTTPConnection(unittest.TestCase):
 
-    def test_discard_buffering_arg_on_py26(self):
-        with mock.patch('httplib.HTTPResponse.__init__') \
-                as mock_http_response_init:
-            kwargs = dict(
-                sock=None, debuglevel=0, strict=0, method=None, buffering=False)
+    @mock.patch('httplib.HTTPResponse.__init__')
+    def test_discard_buffering_arg_on_py26(
+            self, mock_http_response_init):
 
-            response_class = \
-                swift_scality_backend.http_utils.SomewhatBufferedHTTPConnection.HTTPResponse
-            response_obj = response_class(**kwargs)
+        kwargs = dict(
+            sock=None, debuglevel=0, strict=0, method=None, buffering=False)
 
-            if sys.version_info < (2, 7):
-                del kwargs['buffering']
-            mock_http_response_init.assert_called_once_with(
-                response_obj, **kwargs)
+        response_class = \
+            swift_scality_backend.http_utils.SomewhatBufferedHTTPConnection.HTTPResponse
+        response_obj = response_class(**kwargs)
+
+        if sys.version_info < (2, 7):
+            del kwargs['buffering']
+
+        mock_http_response_init.assert_called_once_with(
+            response_obj, **kwargs)


### PR DESCRIPTION
Python 2.6 httlib.HTTPResponse  does not accept a 'buffering' arg.