### PR TITLE
Implement fileno method for py26 compatibility.

### DIFF
--- a/swift_scality_backend/http_utils.py
+++ b/swift_scality_backend/http_utils.py
@@ -112,6 +112,11 @@ class SomewhatBufferedHTTPConnection(httplib.HTTPConnection):
             # possible.
             self.fp = SomewhatBufferedFileObject(sock, 'rb', 1024)
 
+        if not hasattr(httplib.HTTPResponse, 'fileno'):
+            # py26 compat
+            def fileno(self):
+                return self.fp.fileno()
+
     response_class = HTTPResponse
 
     def __enter__(self):

--- a/test/unit/test_http_utils.py
+++ b/test/unit/test_http_utils.py
@@ -138,3 +138,13 @@ class TestSomewhatBufferedHTTPConnection(unittest.TestCase):
 
         mock_http_response_init.assert_called_once_with(
             response_obj, **kwargs)
+
+    @mock.patch('httplib.HTTPResponse.__init__', mock.Mock())
+    def test_fileno_attr(self):
+        response_class = \
+            swift_scality_backend.http_utils.SomewhatBufferedHTTPConnection.HTTPResponse
+        response_obj = response_class(sock=None)
+        with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)) \
+                as sock:
+            response_obj.fp = sock
+            self.assertEquals(sock.fileno(), response_obj.fileno())


### PR DESCRIPTION
Our code expect a fileno method available on HTTPResponse object : 
https://github.com/scality/ScalitySproxydSwift/blob/0.3/swift_scality_backend/diskfile.py#L405

The fileno method on httplib.HTTPResponse is only available starting py27.

