### PR TITLE
Fix `sproxyd_timeout` not being cast as `float`

### DIFF
--- a/swift_scality_backend/server.py
+++ b/swift_scality_backend/server.py
@@ -48,10 +48,19 @@ class ObjectController(swift.obj.server.ObjectController):
         sproxyd_urls = ['http://%s/%s/' % (h, sproxyd_path) for h in
                         swift_scality_backend.utils.split_list(conf['sproxyd_host'])]
 
-        self._filesystem = SproxydClient(sproxyd_urls,
-                                         conf.get('sproxyd_conn_timeout'),
-                                         conf.get('sproxyd_proxy_timeout'),
-                                         self.logger)
+        # We can't pass `None` as value for sproxyd_*_timeout because it will
+        # override the defaults set in SproxydClient
+        kwargs = {}
+
+        sproxyd_conn_timeout = conf.get('sproxyd_conn_timeout')
+        if sproxyd_conn_timeout is not None:
+            kwargs['sproxyd_conn_timeout'] = float(sproxyd_conn_timeout)
+
+        sproxyd_read_timeout = conf.get('sproxyd_proxy_timeout')
+        if sproxyd_read_timeout is not None:
+            kwargs['sproxyd_read_timeout'] = float(sproxyd_read_timeout)
+
+        self._filesystem = SproxydClient(sproxyd_urls, logger=self.logger, **kwargs)
         self._diskfile_mgr = swift_scality_backend.diskfile.DiskFileManager(conf, self.logger)
 
     def get_diskfile(self, device, partition, account, container, obj,

--- a/test/unit/test_server.py
+++ b/test/unit/test_server.py
@@ -17,6 +17,7 @@
 
 import inspect
 
+import mock
 import swift.obj.server
 
 import swift_scality_backend.diskfile
@@ -80,6 +81,17 @@ def test_api_compatible():
             continue
 
         yield check_api_compatible, name
+
+
+@mock.patch('swift_scality_backend.server.SproxydClient')
+def test_setup_with_custom_timeout(mock_sproxyd_client):
+    conf = {'sproxyd_host': 'host1:81', 'sproxyd_proxy_timeout': "10.0",
+            'sproxyd_conn_timeout': "4.1"}
+    swift_scality_backend.server.app_factory(conf)
+
+    mock_sproxyd_client.assert_called_once_with(
+        mock.ANY, sproxyd_read_timeout=10.0, sproxyd_conn_timeout=4.1,
+        logger=mock.ANY)
 
 
 def test_get_diskfile():


### PR DESCRIPTION
Fixes #102