### PR TITLE
Fix wrong SproxydClient arguments name

### DIFF
--- a/swift_scality_backend/server.py
+++ b/swift_scality_backend/server.py
@@ -54,11 +54,11 @@ class ObjectController(swift.obj.server.ObjectController):
 
         sproxyd_conn_timeout = conf.get('sproxyd_conn_timeout')
         if sproxyd_conn_timeout is not None:
-            kwargs['sproxyd_conn_timeout'] = float(sproxyd_conn_timeout)
+            kwargs['conn_timeout'] = float(sproxyd_conn_timeout)
 
         sproxyd_read_timeout = conf.get('sproxyd_proxy_timeout')
         if sproxyd_read_timeout is not None:
-            kwargs['sproxyd_read_timeout'] = float(sproxyd_read_timeout)
+            kwargs['read_timeout'] = float(sproxyd_read_timeout)
 
         self._filesystem = SproxydClient(sproxyd_urls, logger=self.logger, **kwargs)
         self._diskfile_mgr = swift_scality_backend.diskfile.DiskFileManager(conf, self.logger)

--- a/test/unit/test_server.py
+++ b/test/unit/test_server.py
@@ -83,15 +83,13 @@ def test_api_compatible():
         yield check_api_compatible, name
 
 
-@mock.patch('swift_scality_backend.server.SproxydClient')
-def test_setup_with_custom_timeout(mock_sproxyd_client):
+def test_setup_with_custom_timeout():
     conf = {'sproxyd_host': 'host1:81', 'sproxyd_proxy_timeout': "10.0",
             'sproxyd_conn_timeout': "4.1"}
-    swift_scality_backend.server.app_factory(conf)
+    obj_serv = swift_scality_backend.server.app_factory(conf)
 
-    mock_sproxyd_client.assert_called_once_with(
-        mock.ANY, sproxyd_read_timeout=10.0, sproxyd_conn_timeout=4.1,
-        logger=mock.ANY)
+    assert obj_serv._filesystem.read_timeout == 10.0
+    assert obj_serv._filesystem.conn_timeout == 4.1
 
 
 def test_get_diskfile():


### PR DESCRIPTION
Sproxyd client expects `conn_timeout` not `sproxyd_conn_timeout`.
Bug introduced with commit a3bc35b151e5b40060e38669395bfd9e503162cb