### PR TITLE
Properly escape account, container and object names

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -30,3 +30,13 @@ be installed before installing this package.
        sproxyd_host = 172.24.4.3:81,172.24.4.4:81
        sproxyd_path = /proxy/chord
        splice = yes
+
+4. Configure the webserver in front of Scality Sproxyd (usually Apache) to
+   accept encoded slashes (`/`). Swift object name can contain one or several
+   slashes that must be encoded before being sent to Sproxyd. To allow encoded
+   slashes, edit your Apache configuration (or the Sproxyd virtual host) and
+   add the following line:
+
+    .. code-block:: apacheconf
+
+       AllowEncodedSlashes NoDecode

--- a/test/unit/test_diskfile.py
+++ b/test/unit/test_diskfile.py
@@ -185,6 +185,14 @@ class TestDiskFileWriter(unittest.TestCase):
 class TestDiskFile(unittest.TestCase):
     """Tests for swift_scality_backend.diskfile.DiskFile"""
 
+    def test_init_quotes_object_path(self):
+        account, container, obj = 'a', '@/', '/ob/j'
+
+        sproxyd_client = SproxydClient(['http://host:81/path/'], logger=mock.Mock())
+        df = DiskFile(sproxyd_client, account, container, obj,
+                      use_splice=False)
+        self.assertEqual('a/%40%2F/%2Fob%2Fj', df._name)
+
     @mock.patch('scality_sproxyd_client.sproxyd_client.SproxydClient.get_meta',
                 return_value=None)
     def test_open_when_no_metadata(self, mock_get_meta):


### PR DESCRIPTION
This change is required to properly distinguish object names
'ob/j' from object named 'ob//j'. Indeed, some webservers such as
Apache (wrongly ?) mangle consecutive forward slahes. This change
makes sure we properly quote special URL chars.

Fixes #100