### PR TITLE
Support Swift 2.3

### DIFF
--- a/swift_scality_backend/diskfile.py
+++ b/swift_scality_backend/diskfile.py
@@ -103,6 +103,15 @@ class DiskFileWriter(object):
         self.logger.debug("Data successfully written for object : %r", self._name)
         self._filesystem.put_meta(self._name, metadata)
 
+    def commit(self, timestamp):
+        """
+        Perform any operations necessary to mark the object as durable. For
+        replication policy type this is a no-op.
+        :param timestamp: object put timestamp, an instance of
+                          :class:`~swift.common.utils.Timestamp`
+        """
+        pass
+
 
 class DiskFileReader(object):
     """A simple sproxyd pass-through

--- a/swift_scality_backend/server.py
+++ b/swift_scality_backend/server.py
@@ -30,7 +30,7 @@ import swift_scality_backend.diskfile
 import swift_scality_backend.utils
 from scality_sproxyd_client.sproxyd_client import SproxydClient
 
-POLICY_IDX_STUB = object()
+POLICY_STUB = object()
 
 
 class ObjectController(swift.obj.server.ObjectController):
@@ -64,7 +64,7 @@ class ObjectController(swift.obj.server.ObjectController):
         self._diskfile_mgr = swift_scality_backend.diskfile.DiskFileManager(conf, self.logger)
 
     def get_diskfile(self, device, partition, account, container, obj,
-                     policy_idx=POLICY_IDX_STUB, **kwargs):
+                     policy=POLICY_STUB, **kwargs):
         """
         Utility method for instantiating a DiskFile object supporting a
         given REST API.
@@ -74,7 +74,7 @@ class ObjectController(swift.obj.server.ObjectController):
 
     def async_update(self, op, account, container, obj, host, partition,
                      contdevice, headers_out, objdevice,
-                     policy_index=POLICY_IDX_STUB):
+                     policy=POLICY_STUB):
         """Sends or saves an async update.
 
         :param op: operation performed (ex: 'PUT', or 'DELETE')
@@ -87,7 +87,9 @@ class ObjectController(swift.obj.server.ObjectController):
         :param headers_out: dictionary of headers to send in the container
                             request
         :param objdevice: device name that the object is in
-        :param policy_index: the associated storage policy index
+        :param policy: the associated BaseStoragePolicy instance OR the
+                       associated storage policy index (depends on the Swift
+                       version)
         """
         headers_out['user-agent'] = 'obj-server %s' % os.getpid()
         full_path = '/%s/%s/%s' % (account, container, obj)

--- a/test/unit/test_server.py
+++ b/test/unit/test_server.py
@@ -56,7 +56,16 @@ def test_api_compatible():
         assert nargs2 - ndefs2 <= nargs1 - ndefs1, \
             'Incompatible number of non-default args: %r' % name
 
-        assert spec1.args == spec2.args[:nargs1], \
+        # The `policy` arg used to be named  `policy_index` or `policy_idx`
+        # in Swift 2.1 and 2.2. It changed in Swift 2.3.
+        # We rename the arg here to be keep compatibility and have the same
+        # method signature excepted for the name of the `policy` argument.
+        spec1_args = [arg.replace('policy_idx', 'policy').replace(
+            'policy_index', 'policy') for arg in spec1.args]
+        spec2_args = [arg.replace('policy_idx', 'policy').replace(
+            'policy_index', 'policy') for arg in spec2.args]
+
+        assert spec1_args == spec2_args[:nargs1], \
             'Incompatible arg names: %r' % name
 
     def check_api_compatible(name):


### PR DESCRIPTION
* A `commit` method has been added to the DiskFileWriter which is a no-op
except for the EC diskfile.
* The `policy_index` and `policy_idx` arguments in the Object server classe
have been renamed to `policy`