### PR TITLE
Support Swift 2.3

### DIFF
--- a/swift_scality_backend/diskfile.py
+++ b/swift_scality_backend/diskfile.py
@@ -312,6 +312,15 @@ class DiskFileWriter(object):
         self.logger.debug("Data successfully written for object : %s", self.safe_path)
         self._filesystem.put_meta(self._name, metadata)
 
+    def commit(self, timestamp):
+        """
+        Perform any operations necessary to mark the object as durable.
+
+        :param timestamp: object put timestamp, an instance of
+                          :class:`~swift.common.utils.Timestamp`
+        """
+        pass
+
 
 class DiskFileReader(object):
     """A simple sproxyd pass-through

--- a/swift_scality_backend/server.py
+++ b/swift_scality_backend/server.py
@@ -29,7 +29,7 @@ import swift.obj.server
 import swift_scality_backend.diskfile
 
 
-POLICY_IDX_STUB = object()
+POLICY_STUB = object()
 
 
 class ObjectController(swift.obj.server.ObjectController):
@@ -43,7 +43,7 @@ class ObjectController(swift.obj.server.ObjectController):
         self._filesystem = swift_scality_backend.diskfile.SproxydFileSystem(conf, self.logger)
 
     def get_diskfile(self, device, partition, account, container, obj,
-                     policy_idx=POLICY_IDX_STUB, **kwargs):
+                     policy=POLICY_STUB, **kwargs):
         """Utility method for instantiating a DiskFile object supporting a
         given REST API.
         """
@@ -51,7 +51,7 @@ class ObjectController(swift.obj.server.ObjectController):
 
     def async_update(self, op, account, container, obj, host, partition,
                      contdevice, headers_out, objdevice,
-                     policy_index=POLICY_IDX_STUB):
+                     policy=POLICY_STUB):
         """Sends or saves an async update.
 
         :param op: operation performed (ex: 'PUT', or 'DELETE')
@@ -64,7 +64,9 @@ class ObjectController(swift.obj.server.ObjectController):
         :param headers_out: dictionary of headers to send in the container
                             request
         :param objdevice: device name that the object is in
-        :param policy_index: the associated storage policy index
+        :param policy: the associated BaseStoragePolicy instance OR the
+                       associated storage policy index (depends on the Swift
+                       version)
         """
         headers_out['user-agent'] = 'obj-server %s' % os.getpid()
         full_path = '/%s/%s/%s' % (account, container, obj)

--- a/test/unit/test_server.py
+++ b/test/unit/test_server.py
@@ -54,7 +54,17 @@ def test_api_compatible():
         assert nargs2 - ndefs2 <= nargs1 - ndefs1, \
             'Incompatible number of non-default args: %r' % name
 
-        assert spec1.args == spec2.args[:nargs1], \
+        # The `policy` arg used to be named  `policy_index` or `policy_idx`
+        # in Swift 2.1 and 2.2. It changed in Swift 2.3.
+        # We rename the arg here to be keep compatibility and have the same
+        # method signature excepted for the name of the `policy` argument.
+        spec1_args, spec2_args = spec1.args, spec2.args
+        replace = {'policy_idx': 'policy', 'policy_index': 'policy'}
+        if name in ['get_diskfile', 'async_update']:
+            spec1_args = [replace.get(arg, arg) for arg in spec1.args]
+            spec2_args = [replace.get(arg, arg) for arg in spec2.args]
+
+        assert spec1_args == spec2_args[:nargs1], \
             'Incompatible arg names: %r' % name
 
     def check_api_compatible(name):


### PR DESCRIPTION
* A `commit` method has been added to the DiskFileWriter which is a no-op
except for the EC diskfile.
* The `policy_index` and `policy_idx` arguments in the Object server classe
have been renamed to `policy`

Closes: #106