### PR TITLE
Eventlet backward compatibility

### DIFF
--- a/swift_scality_backend/http_utils.py
+++ b/swift_scality_backend/http_utils.py
@@ -20,7 +20,7 @@ import httplib
 import socket
 import sys
 
-import eventlet
+import eventlet.greenio
 
 from swift_scality_backend.exceptions import InvariantViolation
 
@@ -116,7 +116,7 @@ class SomewhatBufferedHTTPConnection(httplib.HTTPConnection):
                 socket._socketobject.makefile = makefile
             # Handle eventlet subtlety
             # https://github.com/eventlet/eventlet/blob/master/eventlet/greenio/base.py#L295
-            if isinstance(sock, eventlet.greenio.base.GreenSocket):
+            if isinstance(sock, eventlet.greenio.GreenSocket):
                 real_sock = sock.dup()
             else:
                 real_sock = sock._sock
@@ -128,7 +128,7 @@ class SomewhatBufferedHTTPConnection(httplib.HTTPConnection):
 
             # Eventlet finalizing
             # https://github.com/eventlet/eventlet/blob/master/eventlet/greenio/base.py#L299
-            if hasattr(real_sock, '_drop') and isinstance(real_sock, eventlet.greenio.base.GreenSocket):
+            if hasattr(real_sock, '_drop') and isinstance(real_sock, eventlet.greenio.GreenSocket):
                 real_sock._drop()
 
         if not hasattr(httplib.HTTPResponse, 'fileno'):

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ minversion = 1.8.1
 [testenv]
 deps =
     swift1.13.1: https://launchpad.net/swift/icehouse/1.13.1/+download/swift-1.13.1.tar.gz
+    swift1.13.1: eventlet==0.9.15
     swift2.0.0: https://launchpad.net/swift/juno/2.0.0/+download/swift-2.0.0.tar.gz
     swift2.1.0: https://launchpad.net/swift/juno/2.1.0/+download/swift-2.1.0.tar.gz
     swift2.2.0: https://launchpad.net/swift/juno/2.2.0/+download/swift-2.2.0.tar.gz


### PR DESCRIPTION
A swift functional test run revealed that http_utils.py is crashing with old versions of eventlet, because we are relying on eventlet's last version package layout.

This PR correct the bug and add a dependency on eventlet==0.9.15 for the swift1.13.1 factor in the tox environment configuration, so that the unit tests not only runs with the latest eventlet version, which was the case before.
We chose 0.9.15 because swift1.13.1 requires eventlet >=0.9.15.