### PR TITLE
CI: Enable verbose execution mode in functional tests

### DIFF
--- a/jenkins/swift-functional-tests/30-run-tests.sh
+++ b/jenkins/swift-functional-tests/30-run-tests.sh
@@ -3,7 +3,7 @@
 SWIFT_DIR=/opt/stack/swift
 sudo pip install -r $SWIFT_DIR/test-requirements.txt
 set +e
-nosetests -w $SWIFT_DIR/test/functional --exe --with-xunit --xunit-file=${WORKSPACE}/nosetests.xml
+nosetests -v -w $SWIFT_DIR/test/functional --exe --with-xunit --xunit-file=${WORKSPACE}/nosetests.xml
 set -e
 echo "Entering WORKSPACE."
 cd $WORKSPACE


### PR DESCRIPTION
By default `nose` only outputs some dots on a single line, and Jenkins seems to use line-buffering, so the console output isn't updated whilst tests are running.

This commit adds the `-v` flag to the `nosetests` call so it prints which test is being executed, and some intermediate results.