### PR TITLE
The AllowEncodedSlashes directive need different value depending on OS

### DIFF
--- a/jenkins/swift-functional-tests/10-install-ring.sh
+++ b/jenkins/swift-functional-tests/10-install-ring.sh
@@ -31,6 +31,19 @@ function set_keep_alive_and_restart {
 }
 
 
+function get_AllowEncodedSlashes {
+    if is_ubuntu; then
+	echo "$UBUNTU_AllowEncodedSlashes"
+    elif is_centos; then
+	echo "$CENTOS_AllowEncodedSlashes"
+    else
+	echo "Unkown distribution"
+	return 1
+    fi
+}
+
+source jenkins/openstack-ci-scripts/jenkins/distro-utils.sh
+AllowEncodedSlashes=$(get_AllowEncodedSlashes)
 SUP_ADMIN_LOGIN="myName"
 SUP_ADMIN_PASS="myPass"
 INTERNAL_MGMT_LOGIN="super"


### PR DESCRIPTION
We need to perform run the swift-functional-tests job with AllowEncodedSlashes set independently on Ubuntu and Centos.