### PR TITLE
Remove 'magic' `swift` and `scality-sproxyd-client` installation

### DIFF
--- a/jenkins/swift-functional-tests/extras.d/55-swift-sproxyd.sh
+++ b/jenkins/swift-functional-tests/extras.d/55-swift-sproxyd.sh
@@ -2,7 +2,8 @@
 
 function install_sproxyd_driver {
     # Get the correct sproxyd-client version from the requirements
-    local scal_sproxyd_client=$(grep 'scality-sproxyd-client' ${WORKSPACE}/requirements.txt)
+    # Currently retrieved from test-requirements.txt, which is a bit of a hack
+    local scal_sproxyd_client=$(grep 'scality-sproxyd-client' ${WORKSPACE}/test-requirements.txt)
     if [[ -n "$scal_sproxyd_client" ]]; then
         sudo pip install "$scal_sproxyd_client"
     fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,10 @@
-https://launchpad.net/swift/juno/2.2.0/+download/swift-2.2.0.tar.gz
-git+https://github.com/scality/scality-sproxyd-client#egg=scality-sproxyd-client
+# Compatible with Swift Icehouse, Juno and Kilo
+# We assume a pre-existing Swift installation, so use whatever your system comes
+# with, don't simply install any version
+swift >=1.13.1,<2.4
+
+# Currently requires scality-sproxyd-client 'master'. This can be retrieved from
+# https://github.com/scality/scality-sproxyd-client
+scality-sproxyd-client
+
 eventlet>=0.9.15

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,8 @@ setenv = VIRTUAL_ENV={envdir}
 
 [testenv:pep8]
 deps =
-    -r{toxinidir}/requirements.txt
+    git+https://github.com/openstack/swift.git#egg=swift
+    git+https://github.com/scality/scality-sproxyd-client#egg=scality-sproxyd-client
     flake8
 commands = flake8
 


### PR DESCRIPTION
To reduce the number of accidental installations of whatever Swift release we point to in `requirements.txt`, this commit removes it altogether, whilst keeping the dependencies.

When running `pip -r requirements.txt` on a system where Swift or scality-sproxyd-client are not installed, this will result in an error and require manual installation.