### PR TITLE
CI: Explicitly install GCC on Ubuntu

### DIFF
--- a/jenkins/install-deps.sh
+++ b/jenkins/install-deps.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -xue
 
 function install_deb {
-    sudo aptitude install -y python-dev libffi-dev make
+    sudo aptitude install -y gcc python-dev libffi-dev make
 }
 
 function install_centos {


### PR DESCRIPTION
Try to work around issues like https://37.187.159.67:5443/job/swift-tox/320/TOXENV=py27-swift1.13.1,host=ubuntu14-large/console