### PR TITLE
Force oslo.i18n < 2.0.0 wich breaks backward compatibility

### DIFF
--- a/jenkins/swift-functional-tests/20-install-openstack.sh
+++ b/jenkins/swift-functional-tests/20-install-openstack.sh
@@ -16,7 +16,7 @@ EOF
         # requires keystoneclient >= 1.0.0
         # whereas keystone requires keystoneclient <= 0.11.2
         # python-glanceclient >= 0.13.1 is required by openstackclient 0.4.1
-        sudo pip install python-glanceclient==0.13.1
+        sudo pip install "python-glanceclient==0.13.1", "oslo.i18n<2.0.0"
     fi
     ./devstack/stack.sh
 }


### PR DESCRIPTION
Since the release of oslo.i18n 2.0.0 (wich got away from the global solo namespace), the functional test job is failing on icehouse during devstack installation.

This pre-install the highest oslo.i18n but below 2.0.0.

A run : https://37.187.159.67:5443/job/swift-functional-tests/188/