### PR TITLE
0.3 for master

### DIFF
--- a/jenkins/swift-functional-tests/20-install-openstack.sh
+++ b/jenkins/swift-functional-tests/20-install-openstack.sh
@@ -16,7 +16,7 @@ EOF
         # requires keystoneclient >= 1.0.0
         # whereas keystone requires keystoneclient <= 0.11.2
         # python-glanceclient >= 0.13.1 is required by openstackclient 0.4.1
-        sudo pip install python-glanceclient==0.13.1
+        sudo pip install "python-glanceclient==0.13.1", "oslo.i18n<2.0.0"
     fi
     ./devstack/stack.sh
 }


### PR DESCRIPTION
Forward port to master of https://github.com/scality/ScalitySproxydSwift/pull/141

A run : https://37.187.159.67:5443/job/swift-functional-tests/191/ which gives 1403 errors.

A previous run on master (https://37.187.159.67:5443/job/swift-functional-tests/186/) gave 1331 errors but with failures on icehouse for each OS, so it is ok that the error number increases.