### PR TITLE
Fix installation of Openstack trunk on Precise and Icehouse on Centos

### DIFF
--- a/jenkins/swift-functional-tests/20-install-openstack.sh
+++ b/jenkins/swift-functional-tests/20-install-openstack.sh
@@ -27,18 +27,18 @@ function ubuntu_common {
     if [[ $DEVSTACK_BRANCH == "stable/icehouse" ]]; then
         sudo aptitude install -y gcc python-dev
     fi
-}
-
-function ubuntu14_specifics {
     # Workaround pip upgrading six without completely removing the old one
-    # which then cause an error.
+    # which then cause an error.    
     sudo easy_install -U six
 }
 
+function ubuntu14_specifics {
+    :
+}
+
 function ubuntu12_specifics {
-    # Workaround pip upgrading cmd2 without completely removing the old one
-    # which then cause an error.
-    sudo easy_install -U cmd2
+    # Nova Kilo and after needs a libvirt >= 0.9.11. Ubuntu 12.04 vanilla ships 0.9.8.
+    sudo add-apt-repository --yes cloud-archive:icehouse
 }
 
 function centos_specifics {

--- a/jenkins/swift-functional-tests/extras.d/55-swift-sproxyd.sh
+++ b/jenkins/swift-functional-tests/extras.d/55-swift-sproxyd.sh
@@ -6,7 +6,10 @@ function install_sproxyd_driver {
     if [[ -n "$scal_sproxyd_client" ]]; then
         sudo pip install "$scal_sproxyd_client"
     fi
-    sudo python setup.py install
+    # For some reason, doing this failed: keystone would not work,
+    # complaining about "ArgsAlreadyParsedError: arguments already parsed:".
+    #sudo python setup.py install
+    sudo pip install .
 }
 
 # Shameless ripoff of devstack/lib/swift


### PR DESCRIPTION
Backport to 0.3 of https://github.com/scality/ScalitySproxydSwift/pull/130

A run : https://37.187.159.67:5443/job/swift-functional-tests/196/, with only 19 errors on each release/os which is pretty low these days.