### PR TITLE
Fix tox job

### DIFF
--- a/jenkins/install-deps.sh
+++ b/jenkins/install-deps.sh
@@ -1,7 +1,8 @@
 #!/bin/bash -xue
 
 function install_deb {
-    sudo aptitude install -y python-dev libffi-dev make
+    sudo aptitude update
+    sudo aptitude install -y python-dev libffi-dev build-essential
 }
 
 function install_centos {

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,4 +5,3 @@ nose
 nosexcover
 openstack.nose_plugin
 nosehtmloutput
-mock>=1.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26-swift1.13.1,py27-swift1.13.1,py27-swift2.2.0,pep8
+envlist = py26-swift1.13.1,py27-swift1.13.1,py27-swift2.2.0,py27-swift2.3.0,pep8
 minversion = 1.8.1
 
 [testenv]
@@ -9,7 +9,10 @@ deps =
     swift2.0.0: https://launchpad.net/swift/juno/2.0.0/+download/swift-2.0.0.tar.gz
     swift2.1.0: https://launchpad.net/swift/juno/2.1.0/+download/swift-2.1.0.tar.gz
     swift2.2.0: https://launchpad.net/swift/juno/2.2.0/+download/swift-2.2.0.tar.gz
+    swift2.3.0: https://launchpad.net/swift/kilo/2.3.0/+download/swift-2.3.0.tar.gz
     swifthead: git+https://github.com/openstack/swift.git#egg=swift
+    py26: mock<1.1,>=1.0
+    py27: mock>=1.0
     -r{toxinidir}/test-requirements.txt
 
 commands = nosetests -v --with-doctest []
@@ -24,10 +27,10 @@ setenv = VIRTUAL_ENV={envdir}
          NOSE_COVER_BRANCHES=1
 
 [testenv:pep8]
-deps =
-    -r{toxinidir}/requirements.txt
-    flake8
-commands = flake8
+install_command = echo {packages}
+commands = 
+  pip install flake8
+  flake8
 
 [testenv:cover]
 deps =


### PR DESCRIPTION
Add swit-2.3.0 target

Avoid to install anything except flake8 which is the only thing needed in the pep8 env
(this is how Swift does it : https://github.com/openstack/swift/blob/49e7c25876cf4d3bc9412443f881e8472e88e827/tox.ini)

Mock 1.1 (latest version as the time of writing) dropped py26 compatibility.
Can't have mock dependency both in test-requirements.txt and tox.ini,
otherwise pip crashes with 'Double requirement given' error.
That might be fixed in a future version of pip :
see https://github.com/pypa/pip/issues/56
and https://github.com/pypa/pip/issues/988