### PR TITLE
Pin PyECLib version for Swift 2.3.0 tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps =
     swifthead: git+https://github.com/openstack/swift.git#egg=swift
     py26: mock<1.1,>=1.0
     py27: mock>=1.0
+    swift2.3.0: PyECLib==1.0.7
     -r{toxinidir}/test-requirements.txt
 
 commands = nosetests -v --with-doctest []


### PR DESCRIPTION
When using Swift 2.3.0, a non-working version of PyECLib tends to be
pulled from PyPI. This patch pins the dependency version to what's
pinned in the OpenStack Kilo release.