### PR TITLE
Handle recent `coverage` versions

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,3 @@
 [run]
 branch = True
 omit = /usr*,setup.py,*egg*,.venv/*,.tox/*,test/*
-
-[report]
-ignore-errors = True


### PR DESCRIPTION
New versions of `coverage` don't like the `ignore-errors` setting::

    coverage.misc.CoverageException: Unrecognized option '[report]
    ignore-errors=' in config file .coveragerc

Remove it accordingly.