### PR TITLE
Func tests: don"t expect the `keepalive` ENV var to be set

### DIFF
--- a/jenkins/swift-functional-tests/00-variables-check.sh
+++ b/jenkins/swift-functional-tests/00-variables-check.sh
@@ -1,4 +1,3 @@
 #!/bin/bash -xue
 
-test -n "${KEEPALIVE:-}" || (echo "KEEPALIVE should be defined." && return 1);
 test -n "${DEVSTACK_BRANCH:-}" || (echo "DEVSTACK_BRANCH should be defined." && return 1);


### PR DESCRIPTION
The default value for the `keepalive` variable is now set by the
install_ring lib itself.