### PR TITLE
Actually run Hacking rules as part of PEP8 target

### DIFF
--- a/swift_scality_backend/diskfile.py
+++ b/swift_scality_backend/diskfile.py
@@ -115,8 +115,7 @@ class DiskFileWriter(object):
             self._name, metadata)
 
     def commit(self, timestamp):
-        """
-        Perform any operations necessary to mark the object as durable.
+        """Perform any operations necessary to mark the object as durable.
 
         :param timestamp: object put timestamp, an instance of
                           :class:`~swift.common.utils.Timestamp`
@@ -207,8 +206,7 @@ class DiskFileReader(object):
 
     @utils.trace
     def app_iter_range(self, start, stop):
-        """
-        Iterate over a range.
+        """Iterate over a range.
 
         :param start: First byte to read from (inclusive)
         :type start: int
@@ -375,8 +373,7 @@ class DiskFile(object):
 
 
 class DiskFileManager(object):
-    """
-    Management class for devices, providing common place for shared parameters
+    """Management class for devices, providing common place for shared parameters
     and methods not provided by the DiskFile class (which primarily services
     the object server REST API layer).
 
@@ -385,7 +382,8 @@ class DiskFileManager(object):
     """
 
     def __init__(self, conf, logger):
-        """
+        """Init method
+
         :param conf: caller provided configuration object
         :param logger: caller provided logger
         """

--- a/swift_scality_backend/server.py
+++ b/swift_scality_backend/server.py
@@ -213,8 +213,7 @@ class ObjectController(swift.obj.server.ObjectController):
 
     def get_diskfile(self, device, partition, account, container, obj,
                      policy=POLICY_STUB, **kwargs):
-        """
-        Utility method for instantiating a DiskFile object supporting a
+        """Utility method for instantiating a DiskFile object supporting a
         given REST API.
         """
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
 # Hacking already pins down pep8, pyflakes and flake8
-hacking>=0.8.0,<0.9
+hacking>=0.10.0,<0.11
 coverage
 nose
 git+https://github.com/scality/scality-sproxyd-client#egg=scality-sproxyd-client

--- a/test/scenario/multi-backend/fabfile/bootstrap.py
+++ b/test/scenario/multi-backend/fabfile/bootstrap.py
@@ -1,3 +1,18 @@
+# Copyright (c) 2015 Scality
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 
 import saio
@@ -9,8 +24,7 @@ from fabric.context_managers import cd, hide, prefix, settings
 
 @task
 def swift(swift_user):
-    """
-    Bootstrap a SAIO installation.
+    """Bootstrap a SAIO installation.
 
     :param swift_user: the user to run swift as
     :type swift_user: string
@@ -37,8 +51,7 @@ def swift(swift_user):
 
 @task
 def ring():
-    """
-    Bootstrap Scality RING (environment variable `SCAL_PASS` must be exported).
+    """Bootstrap Scality RING (environment variable `SCAL_PASS` must be exported).
 
     The environment variable `SCAL_PASS` is expected to hold username:password
     for fetching scality packages.
@@ -72,8 +85,7 @@ def ring():
 
 @task
 def scality_storage_policy(swift_user, sproxyd_endpoint):
-    """
-    Install a storage policy backed by Scality RING.
+    """Install a storage policy backed by Scality RING.
 
     :param swift_user: the user swift is running as
     :type swift_user: string

--- a/test/scenario/multi-backend/fabfile/saio.py
+++ b/test/scenario/multi-backend/fabfile/saio.py
@@ -1,3 +1,18 @@
+# Copyright (c) 2015 Scality
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import os.path
 

--- a/test/scenario/multi-backend/fabfile/utils.py
+++ b/test/scenario/multi-backend/fabfile/utils.py
@@ -1,3 +1,18 @@
+# Copyright (c) 2015 Scality
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os.path
 
 import fabric.contrib.files
@@ -6,8 +21,7 @@ from fabric.api import cd, sudo
 
 
 def render(directory, filenames, local_path_prefix, content):
-    """
-    Render a list of templates in a certain directory and upload them.
+    """Render a list of templates in a certain directory and upload them.
 
     :param directory: local directory holding templates
     :type directory: string
@@ -32,8 +46,7 @@ def render(directory, filenames, local_path_prefix, content):
 
 
 def build_object_ring(swift_user, name, devices, part_power=10, replicas=3):
-    """
-    Build a swift object ring by invocation of `swift-ring-builder`.
+    """Build a swift object ring by invocation of `swift-ring-builder`.
 
     :param swift_user: the user running swift
     :type swift_user: string
@@ -62,8 +75,7 @@ def build_object_ring(swift_user, name, devices, part_power=10, replicas=3):
 
 
 def apt_get(packages):
-    """
-    Install packages through apt-get.
+    """Install packages through apt-get.
 
     :param packages: list of packages for installation
     :type packages: list of strings

--- a/test/scenario/multi-backend/fabfile/validate.py
+++ b/test/scenario/multi-backend/fabfile/validate.py
@@ -1,6 +1,21 @@
+# Copyright (c) 2015 Scality
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import hashlib
-import json
 import io
+import json
 import os
 
 import swiftclient.client
@@ -12,8 +27,7 @@ AUTH_ENDPOINT = 'http://{host:s}:8080/auth/v1.0'
 
 
 def hash_dataset(directory, manifest_path=None):
-    """
-    SHA1 hash the content of each file in the given directory.
+    """SHA1 hash the content of each file in the given directory.
 
     :param directory: containing directory of files to compute hashes of
     :type directory: string
@@ -39,8 +53,7 @@ def hash_dataset(directory, manifest_path=None):
 
 
 def summarize(failures):
-    """
-    Print a summary of any failures to stdout.
+    """Print a summary of any failures to stdout.
 
     :param failues: mapping of objects with bad integrity to an error string
     :type failures: dict
@@ -54,8 +67,7 @@ def summarize(failures):
 
 
 def create_container(swift_connection, name, storage_policy=None):
-    """
-    Create a container with an optional storage policy.
+    """Create a container with an optional storage policy.
 
     :param swift_connection: connection to Swift
     :type swift_connection: :py:class:`swiftclient.client.Connection`
@@ -71,8 +83,7 @@ def create_container(swift_connection, name, storage_policy=None):
 
 
 def upload(swift_connection, container, files):
-    """
-    Upload a set of files to a container.
+    """Upload a set of files to a container.
 
     :param swift_connection: connection to Swift
     :type swift_connection: :py:class:`swiftclient.client.Connection`
@@ -87,8 +98,7 @@ def upload(swift_connection, container, files):
 
 
 def integrity_check(swift_connection, container, file_hashes):
-    """
-    Download and verify the integrity of a set of files from a bucket.
+    """Download and verify the integrity of a set of files from a bucket.
 
     :param swift_connection: connection to Swift
     :type swift_connection: :py:class:`swiftclient.client.Connection`
@@ -127,8 +137,7 @@ def integrity_check(swift_connection, container, file_hashes):
 @task
 def container_integrity(swift_host, container, directory, storage_policy=None,
                         manifest_path=None, user='test:tester', key='testing'):
-    """
-    Upload files to a container and validate integrity.
+    """Upload files to a container and validate integrity.
 
     :param swift_host: hostname or IP of SAIO installation
     :type swift_host: string
@@ -167,8 +176,7 @@ def container_integrity(swift_host, container, directory, storage_policy=None,
 @task
 def container_by_manifest(swift_host, container, manifest_path,
                           user='test:tester', key='testing'):
-    """
-    Validate the integrity of the files in a container from a manifest.
+    """Validate the integrity of the files in a container from a manifest.
 
     :param swift_host: hostname or IP of SAIO installation
     :type swift_host: string

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -107,7 +107,7 @@ class TestStoragePolicyLint(unittest.TestCase):
 
         rc = cli.storage_policy_lint(args)
 
-        self.assertEquals(0, rc)
+        self.assertEqual(0, rc)
 
 
 class TestStoragePolicyQuery(unittest.TestCase):

--- a/test/unit/test_diskfile.py
+++ b/test/unit/test_diskfile.py
@@ -24,13 +24,13 @@ import mock
 import swift.common.exceptions
 import swift.common.utils
 
-from swift_scality_backend.diskfile import DiskFileWriter, \
-    DiskFileReader, DiskFile, DiskFileManager
-from scality_sproxyd_client.exceptions import SproxydHTTPException
-from swift_scality_backend.http_utils import ClientCollection
-from scality_sproxyd_client.sproxyd_client import SproxydClient
 from . import utils
 from .utils import make_client_collection
+from scality_sproxyd_client.exceptions import SproxydHTTPException
+from scality_sproxyd_client.sproxyd_client import SproxydClient
+from swift_scality_backend.diskfile import DiskFileWriter, \
+    DiskFileReader, DiskFile, DiskFileManager
+from swift_scality_backend.http_utils import ClientCollection
 
 
 NEW_SPLICE = 'new_splice'

--- a/test/unit/test_http_utils.py
+++ b/test/unit/test_http_utils.py
@@ -24,8 +24,8 @@ import unittest
 import eventlet
 import mock
 
-import swift_scality_backend.http_utils
 from . import utils
+import swift_scality_backend.http_utils
 
 
 class TestSomewhatBufferedFileObject(unittest.TestCase):
@@ -155,7 +155,7 @@ class TestSomewhatBufferedHTTPConnection(unittest.TestCase):
             response_class = \
                 swift_scality_backend.http_utils.SomewhatBufferedHTTPConnection.HTTPResponse
             response_obj = response_class(sock=sock)
-            self.assertEquals(sock.fileno(), response_obj.fileno())
+            self.assertEqual(sock.fileno(), response_obj.fileno())
 
     @mock.patch('socket._socketobject.makefile')
     def test_makefile_not_called(self, mock_makefile):

--- a/test/unit/test_ranges.py
+++ b/test/unit/test_ranges.py
@@ -32,9 +32,9 @@ import eventlet
 import swift_scality_backend.server
 
 import swift.account.server
-import swift.container.server
 import swift.common.ring
 import swift.common.utils
+import swift.container.server
 import swift.proxy.server
 
 # Pre storage-policy compatibility
@@ -46,10 +46,9 @@ except ImportError:
 
 
 class TestRangeHeaders(unittest.TestCase):
-    """
-    Test outgoing range headers to sproxyd from the object server on a partial
-    get of an object. See
-    https://github.com/scality/ScalitySproxydSwift/issues/121 for more details.
+    """Test outgoing range headers to sproxyd from the object server on a partial
+    get of an object. See https://github.com/scality/ScalitySproxydSwift/issues/121
+    for more details.
     """
 
     def setUp(self):
@@ -140,8 +139,7 @@ class TestRangeHeaders(unittest.TestCase):
         shutil.rmtree(self.swift_dir, ignore_errors=1)
 
     def _get(self, path, headers):
-        """
-        Send a HTTP GET request to the swift test proxy.
+        """Send a HTTP GET request to the swift test proxy.
 
         :param path: Request path
         :type path: str
@@ -231,9 +229,7 @@ class TestRangeHeaders(unittest.TestCase):
         self.assertEqual(response_headers['content-length'], '1')
 
     def setup_ring(self, server_name, app, bind_address):
-        """
-        Setup a single replica ring.
-        """
+        """Setup a single replica ring."""
         # Device definition
         server_socket = eventlet.listen(bind_address)
         self.sockets.append(server_socket)

--- a/test/unit/test_server.py
+++ b/test/unit/test_server.py
@@ -34,8 +34,7 @@ from . import utils
 
 
 def test_api_compatible():
-    '''
-    Test whether `swift_scality_backend.server.app_factory`'s result is
+    '''Test whether `swift_scality_backend.server.app_factory`'s result is
     API-compatible with `swift.obj.server.app_factory`'s result
     '''
     whitelist = [

--- a/test/unit/utils.py
+++ b/test/unit/utils.py
@@ -29,8 +29,7 @@ from scality_sproxyd_client.sproxyd_client import SproxydClient
 
 
 def skipIf(condition, reason):
-    """
-    A `skipIf` decorator.
+    """A `skipIf` decorator.
 
     Similar to `unittest.skipIf`, for Python 2.6 compatibility.
     """

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ whitelist_externals =
   echo
 install_command = echo {packages}
 commands =
-  pip install flake8
+  pip install -r test-requirements.txt
   flake8
 
 [testenv:pylint]
@@ -48,9 +48,13 @@ commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
 
 [flake8]
-# H302  import only modules.
-# H405 multi line docstring should start without a leading new line
+# H201  no 'except:' at least use 'except Exception:'
+# H233 Python 3.x incompatible use of print operator
+# H301 one import per line
+# H302 import only modules
+# H304 no relative imports
+# H405 multi line docstring summary not separated with an empty line
 # E501 line too long
-ignore = H302,H405,E501
+ignore = H201,H233,H301,H302,H304,H405,E501
 exclude = .venv,.git,.tox,dist,doc,*egg,build\
 	,test/scenario/multi-backend/fabfile/__init__.py


### PR DESCRIPTION
For some reason, Hacking was not installed by the pep8 tox target.
This patch makes sure Hacking is installed and run when pep8 tests
are run. Also this patch fixes a couple of violations.
