### PR TITLE
Support Expiring Objects

### DIFF
--- a/jenkins/swift-functional-tests/40-run-tempest-tests.sh
+++ b/jenkins/swift-functional-tests/40-run-tempest-tests.sh
@@ -5,7 +5,7 @@ cd /opt/stack/tempest
 # Once https://review.openstack.org/#/c/242076/ is merged we should also enable
 # Tempest scenarios
 set +e
-tox -e all -- 'tempest.api.object_storage(?!.*test_object_expiry)(?!.*with_expect_continue)(?!.*ContainerSyncMiddlewareTest.test_container_synchronization)'
+tox -e all -- 'tempest.api.object_storage(?!.*with_expect_continue)(?!.*ContainerSyncMiddlewareTest.test_container_synchronization)'
 set -e
 
 testr last --subunit | subunit2junitxml -o ${WORKSPACE}/tempest-tests.xml

--- a/swift_scality_backend/diskfile.py
+++ b/swift_scality_backend/diskfile.py
@@ -22,6 +22,7 @@ import functools
 import httplib
 import itertools
 import pickle
+import time
 import urllib
 
 import eventlet
@@ -481,6 +482,16 @@ class DiskFile(object):
         if metadata is None:
             raise swift.common.exceptions.DiskFileDeleted()
         self._metadata = metadata or {}
+
+        try:
+            x_delete_at = int(self._metadata['X-Delete-At'])
+        except KeyError:
+            pass
+        else:
+            if x_delete_at <= time.time():
+                raise swift.common.exceptions.DiskFileExpired(
+                    metadata=self._metadata)
+
         return self
 
     @utils.trace


### PR DESCRIPTION
Our diskFile now raises a DiskFileExpired exception if it tries
to open an expired object.
The object-expirer daemon is in charge of actually deleting the expired
objects.