### PR TITLE
Hash the account, container and object name

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -20,6 +20,7 @@ Contents:
 
    installation
    supported_distros
+   misc
    api/modules
 
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -35,13 +35,3 @@ be installed before installing this package.
        [app:object-server]
        sproxyd_endpoints = http://172.24.4.3:81/proxy/bparc,http://172.24.4.4:81/proxy/bparc
        splice = yes
-
-4. Configure the webserver in front of Scality Sproxyd (usually Apache) to
-   accept encoded slashes (`/`). Swift object name can contain one or several
-   slashes that must be encoded before being sent to Sproxyd. To allow encoded
-   slashes, edit your Apache configuration (or the Sproxyd virtual host) and
-   add the following line:
-
-    .. code-block:: apacheconf
-
-       AllowEncodedSlashes NoDecode

--- a/doc/misc.rst
+++ b/doc/misc.rst
@@ -1,0 +1,32 @@
+Misc
+====
+
+Backward incompatible change
+----------------------------
+Git commit b8dc82e4 (January 2016) introduced a major backward incompatible
+change in how a Swift object (identified by its name) is mapped into a Sproxyd
+path. As such any Swift object put with a version of `swift-scality-backend`
+that does not have commit b8dc82e4 will be unreachable once
+`swift-scality-backend` is upgraded.
+
+This is only a concern for non-POC installations running
+`swift-scality-backend` version 0.3 that would like to upgrade to a newer
+version of `swift-scality-backend`. In that case a proper migration strategy
+would have to be put in place.
+
+Mapping of Swift names to Sproxyd paths
+---------------------------------------
+In OpenStack Swift, the canonical URL to an object is 
+http://swiftproxyhost/account/container/object where `account` is the account
+ID of the user, `container` is the container name and `object` the object name.
+`swift-scality-backend` requires Sproxyd to be configured to accept queries "by 
+path". The Sproxyd path is derived by SHA1-hashing the concatenation of
+`account`, `container` and `object`. This way, the Swift object can be retrieved
+directly though Sproxyd at this location:
+http://sproxydhost/proxy/namespace/SHA1(account+container+object)
+
+**N.B**: `namespace` is usually "bpchord" or "bparc".
+
+This is useful to debug a Swift installation that use the Scality backend.
+
+

--- a/jenkins/swift-functional-tests/10-install-ring.sh
+++ b/jenkins/swift-functional-tests/10-install-ring.sh
@@ -1,19 +1,6 @@
 #!/bin/bash -xue
 
-
-function get_AllowEncodedSlashes {
-    if is_ubuntu; then
-        echo "$UBUNTU_AllowEncodedSlashes"
-    elif is_centos; then
-        echo "$CENTOS_AllowEncodedSlashes"
-    else
-        echo "Unkown distribution"
-        return 1
-    fi
-}
-
 source jenkins/openstack-ci-scripts/jenkins/distro-utils.sh
-AllowEncodedSlashes=$(get_AllowEncodedSlashes)
 
 SUP_ADMIN_LOGIN="myName"
 SUP_ADMIN_PASS="myPass"

--- a/test/scenario/multi-backend/fabfile/bootstrap.py
+++ b/test/scenario/multi-backend/fabfile/bootstrap.py
@@ -50,7 +50,6 @@ def ring():
         'INTERNAL_MGMT_PASS': 'admin',
         'HOST_IP': env.host,
         'SCAL_PASS': os.environ['SCAL_PASS'],
-        'AllowEncodedSlashes': 'NoDecode',
     }
     export_vars = ('{0:s}={1:s}'.format(k, v) for k, v in install_env.items())
     export_cmd = 'export {0:s}'.format(' '.join(export_vars))


### PR DESCRIPTION
With this, no need to change the Apache config flag 'AllowEncodedSlahes'
and we also get consistent behavior with all web servers.

Warning: this is completely backward incompatible. No Swift object put before
this commit will be reachable once this patch is merged. Users of the 0.3
branch of this project should do a full copy of their Swift cluster if they
want to migrate to this branch.