### PR TITLE
Tox.ini, Swift 1.13 target: remove requirement on eventlet=0.9.15

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@ minversion = 1.8.1
 [testenv]
 deps =
     swift1.13.1: https://launchpad.net/swift/icehouse/1.13.1/+download/swift-1.13.1.tar.gz
-    swift1.13.1: eventlet==0.9.15
     swift2.0.0: https://launchpad.net/swift/juno/2.0.0/+download/swift-2.0.0.tar.gz
     swift2.1.0: https://launchpad.net/swift/juno/2.1.0/+download/swift-2.1.0.tar.gz
     swift2.2.0: https://launchpad.net/swift/juno/2.2.0/+download/swift-2.2.0.tar.gz


### PR DESCRIPTION
It seems eventlet>=0.9.15 (from requirements.txt) is enough. Not need for
exactly 0.9.15.