### PR TITLE
Fix `ObjectController` API-compatibility

### DIFF
--- a/swift_scality_backend/server.py
+++ b/swift_scality_backend/server.py
@@ -101,7 +101,7 @@ class ObjectController(swift.obj.server.ObjectController):
                     {'ip': ip, 'port': port, 'dev': contdevice})
         # FIXME: For now don't handle async updates
 
-    def REPLICATE(*_args, **_kwargs):
+    def REPLICATE(ctrl=None, *_args, **_kwargs):
         """Handle REPLICATE requests for the Swift Object Server.
 
         This is used by the object replicator to get hashes for directories.


### PR DESCRIPTION
In Swift `master`, the prototype of the `REQUEST` method of the
`ObjectController` changed API, taking a `ctrl` argument now (introduced
by the `timing_stats` decorator).

This commit adds the argument to 'our' `ObjectController` to restore
compatibility.