### PR TITLE
Scheduled weekly func-tests run in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,3 +91,13 @@ workflows:
           requires:
             - build
       - func-tests
+  weekly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * 0"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - func-tests


### PR DESCRIPTION
Scheduled weekly func-tests run at 00:00 on Sunday, so that new blocking changes on the Openstack Swift master branch will give a red build till our code is updated