### PR TITLE
Change USER from stack (doesn't exist) to swift

### DIFF
--- a/rhosp_container/Dockerfile
+++ b/rhosp_container/Dockerfile
@@ -18,5 +18,5 @@ RUN cd /tmp \
   && cd ScalitySproxydSwift-swift-scality-backend-0.4.4 \
   && python setup.py install
 
-USER stack
+USER swift
 


### PR DESCRIPTION
This solves an issue with the container image failing the certification scan. The rpm_list_successful runs the `rpm -qa` command in docker on the running container, however this container fails to run in the current configuration, since the user "stack" does not exist in the container image.